### PR TITLE
feat(update-bootsrap): add the modularity to the main script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,80 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+*~
+
+# Downloaded dependencies (keep notice files)
+bin/*
+!bin/notice.txt
+futurerestore/*
+!futurerestore/notice.txt
+lib/
+!scripts/core/lib/
+!scripts/core/lib/**
+activate.sh
+backup.sh
+main.c
+
+# Dependency build clones
+asr64_patcher/
+restored_external64patcher/
+libimg4_patcher/
+openra1n/
+
+# Runtime temp / work directories
+tmp*/
+tmpmanifest/
+work/
+updatefiles/
+jbresources/
+sshrd/
+sshramdisk/
+
+# Generated restore artifacts
+noseprestore/
+restorefiles/
+seprmvr64boot/
+cache/
+activation_records/
+
+# Device / activation files (sensitive, generated at runtime)
+activation.plist
+IC-Info.sisv
+com.apple.commcenter.device_specific_nobackup.plist
+dyld.raw
+dyld.patched
+asr
+asr_patch
+restored_external
+restored_patch
+ents.plist
+options.n61.plist
+
+# Large firmware / restore files
+*.ipsw
+*.dmg
+*.bbfw
+*.dfu
+*.im4p
+*.img4
+*.im4m
+*.shsh
+*.shsh2
+*.raw
+*.ipa
+
+# Logs
+*.log
+
+# C build artifacts
+src/*.o
+surrealra1n

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,84 @@
+# surrealra1n modular architecture
+
+This document describes the new modular runtime used by `surrealra1n_new.sh`.
+
+## Entry points
+
+- `surrealra1n.sh`
+  - Original monolithic script kept for compatibility.
+- `surrealra1n_new.sh`
+  - New modular entry point.
+  - This is the script that routes execution into modules.
+
+## High-level execution flow
+
+1. `surrealra1n_new.sh` starts.
+2. Core bootstrap is loaded (`scripts/core/lib/bootstrap.sh`).
+3. Auto-update checks are executed (`scripts/core/lib/auto_update.sh`).
+4. Command dispatcher routes to a command module (`scripts/core/lib/dispatch.sh`).
+5. Command module runs:
+   - shared runtime init (`scripts/core/lib/runtime_context.sh`)
+   - command-specific logic (`scripts/commands/<command>.sh`)
+
+## Directory layout
+
+- `scripts/core/lib/`
+  - Shared framework-level modules:
+    - `bootstrap.sh` - base environment setup.
+    - `usage.sh` - unified CLI usage text.
+    - `auto_update.sh` - update checks and pull/restart flow.
+    - `dispatch.sh` - command-to-module routing.
+    - `flows.sh` - reusable operational flows (pwndfu, shsh, key reads).
+    - `command_helpers.sh` - argument normalization and flag helpers.
+    - `runtime_context.sh` - runtime orchestrator + top-level error trap.
+
+- `scripts/core/lib/runtime/`
+  - Runtime internals split by responsibility:
+    - `prepare_environment.sh` - dependency/bin setup and preflight.
+    - `detect_device.sh` - device detection (normal/recovery/dfu).
+    - `apply_profiles.sh` - device profile and variable assignment.
+
+- `scripts/commands/`
+  - One command per file, each containing command-specific logic:
+    - `seprmvr64_ipsw.sh`
+    - `seprmvr64_restore.sh`
+    - `seprmvr64_boot.sh`
+    - `make_custom_ipsw.sh`
+    - `make_custom_ipsw_2.sh`
+    - `restore.sh`
+    - `downgrade.sh`
+    - `boot.sh`
+    - `fix_ios8.sh`
+
+## Command module contract
+
+Each command module should follow this pattern:
+
+1. `source` required core libs.
+2. Define `cmd_<name>()` function.
+3. Define `main()` that:
+   - calls `bootstrap_environment`
+   - calls `init_runtime_context`
+   - calls `cmd_<name> "$@"`
+4. Call `main "$@"`.
+
+## Shared helpers policy
+
+When logic is reused by two or more commands:
+
+- Put command-oriented helpers in `scripts/core/lib/flows.sh`.
+- Put CLI/arg helpers in `scripts/core/lib/command_helpers.sh`.
+- Keep command files focused on command-specific business logic.
+
+## Adding a new command
+
+1. Create `scripts/commands/<new_command>.sh`.
+2. Implement `cmd_<new_command>()` using existing helpers.
+3. Register the command in `scripts/core/lib/dispatch.sh`.
+4. Update `scripts/core/lib/usage.sh`.
+5. Validate with:
+   - `bash -n scripts/core/lib/*.sh`
+   - `bash -n scripts/core/lib/runtime/*.sh`
+   - `bash -n scripts/commands/*.sh`
+   - `./surrealra1n_new.sh --help`
+

--- a/scripts/commands/boot.sh
+++ b/scripts/commands/boot.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+. "$PROJECT_ROOT/scripts/core/lib/bootstrap.sh"
+. "$PROJECT_ROOT/scripts/core/lib/usage.sh"
+. "$PROJECT_ROOT/scripts/core/lib/runtime_context.sh"
+. "$PROJECT_ROOT/scripts/core/lib/command_helpers.sh"
+. "$PROJECT_ROOT/scripts/core/lib/flows.sh"
+
+cmd_boot() {
+    normalize_command_args "--boot" "$@"
+    local args=("${NORMALIZED_ARGS[@]}")
+
+    if [[ ${#args[@]} -ne 1 ]]; then
+        echo "[!] Usage: --boot [iOS_VERSION]"
+        exit 1
+    fi
+    IOS_VERSION="${args[0]}"
+    echo "[*] Tethered boot of iOS $IOS_VERSION..."
+    echo "[!] Note: Kernel patches are applied for restoring only usually"
+    # Find the .shsh2 file in the shsh directory
+    shshpath=$(require_shsh_blob "shsh")
+       
+
+    # Check for boot files
+    BOOT_DIR="boot/$IDENTIFIER/$IOS_VERSION"
+    if [[ ! -d "$BOOT_DIR" ]] || [[ ! -f "$BOOT_DIR"/iBSS.img4 || ! -f "$BOOT_DIR"/iBEC.img4 || ! -f "$BOOT_DIR"/DeviceTree.img4 || ! -f "$BOOT_DIR"/Kernelcache.img4 ]]; then
+        echo "[*] Boot files not found. Creating new boot files at $BOOT_DIR..."
+        if [[ $IDENTIFIER == iPhone10* ]] && [[ $IOS_VERSION == 14.2* || $IOS_VERSION == 14.1* || $IOS_VERSION == 14.0* ]]; then
+            IPSW_PATH="restorefiles/$IDENTIFIER/$IOS_VERSION/custom.ipsw"
+        else
+            echo "Drag and drop the iOS $IOS_VERSION IPSW file."
+            IPSW_PATH=$($zenity --file-selection --title="Select the iOS $IOS_VERSION IPSW file")
+        fi
+        if [[ -z "$IPSW_PATH" ]]; then
+            echo "[!] No IPSW selected. Aborting."
+            sudo rm -rf "$BOOT_DIR"
+            exit 1
+        fi
+        if [[ ! -f "$IPSW_PATH" ]]; then
+            echo "[!] IPSW does not exist: $IPSW_PATH"
+            sudo rm -rf "$BOOT_DIR"
+            exit 1
+        fi
+        mkdir -p to_patch
+        mkdir -p "$BOOT_DIR"
+        # move ibss and ibec
+        if [[ "$IOS_VERSION" == 10.2* || "$IOS_VERSION" == 10.1* ]]; then
+            unzip -j "$IPSW_PATH" "Firmware/dfu/$IBSS10" -d to_patch
+            unzip -j "$IPSW_PATH" "Firmware/dfu/$IBEC10" -d to_patch
+            unzip -j "$IPSW_PATH" "$KERNELCACHE10" -d to_patch
+            mv to_patch/$KERNELCACHE10 to_patch/$KERNELCACHE
+            mv to_patch/$IBSS10 to_patch/$IBSS
+            mv to_patch/$IBEC10 to_patch/$IBEC
+        else
+            unzip -j "$IPSW_PATH" "Firmware/dfu/$IBSS" -d to_patch
+            unzip -j "$IPSW_PATH" "Firmware/dfu/$IBEC" -d to_patch
+            unzip -j "$IPSW_PATH" "$KERNELCACHE" -d to_patch
+        fi
+        if [[ "$IOS_VERSION" == 10.1* || "$IOS_VERSION" == 10.2* ]]; then
+            unzip -j "$IPSW_PATH" "Firmware/all_flash/$ALLFLASH/$DEVICETREE" -d to_patch
+        else
+            unzip -j "$IPSW_PATH" "Firmware/all_flash/$DEVICETREE" -d to_patch
+        fi
+        if [[ "$IOS_VERSION" == 12.* || "$IOS_VERSION" == 13.* || "$IOS_VERSION" == 14.* || "$IOS_VERSION" == 15.* ]]; then
+            echo "Trustcache will be extracted too!"
+            unzip -j "$IPSW_PATH" "Firmware/*.dmg.trustcache" -d to_patch
+            # Select the biggest trustcache file
+            BIGGEST_TRUSTCACHE=$(ls -S to_patch/*.trustcache 2>/dev/null | head -n 1)
+            if [[ -n "$BIGGEST_TRUSTCACHE" ]]; then
+                echo "[*] Using biggest trustcache: $(basename "$BIGGEST_TRUSTCACHE")"
+                cp "$BIGGEST_TRUSTCACHE" to_patch/trustcache
+            else
+                echo "[!] No trustcache file found in IPSW."
+            fi
+        fi
+        mv to_patch/$IBSS to_patch/iBSS.im4p
+        mv to_patch/$IBEC to_patch/iBEC.im4p
+        mv to_patch/$DEVICETREE to_patch/DeviceTree.im4p
+        mv to_patch/$KERNELCACHE to_patch/kernelcache
+
+        # Read decryption keys
+        KEY_FILE="keys/$IDENTIFIER.txt"
+        if [[ ! -f "$KEY_FILE" ]]; then
+            echo "[!] Key file $KEY_FILE not found. Aborting."
+            exit 1
+        fi
+
+        # Extract iBSS and iBEC keys
+        IBSS_KEY=$(read_key_value "$KEY_FILE" "ibss-$IOS_VERSION")
+        IBEC_KEY=$(read_key_value "$KEY_FILE" "ibec-$IOS_VERSION")
+
+        if [[ -z "$IBSS_KEY" || -z "$IBEC_KEY" ]]; then
+            echo "[!] Missing iBSS or iBEC key for iOS $IOS_VERSION in $KEY_FILE. Aborting."
+            exit 1
+        fi
+
+        echo "[*] Found keys:"
+        echo "    iBSS Key: $IBSS_KEY"
+        echo "    iBEC Key: $IBEC_KEY"
+
+        # Placeholder for actual boot file creation
+        echo "[*] Creating boot files..."
+        ./bin/img4tool -s "$shshpath" -e -m "$IDENTIFIER-im4m"
+        im4m="$IDENTIFIER-im4m"
+        ./bin/img4 -i to_patch/iBSS.im4p -o to_patch/iBSS.dec -k $IBSS_KEY
+        ./bin/img4 -i to_patch/iBEC.im4p -o to_patch/iBEC.dec -k $IBEC_KEY
+        if [[ "$IOS_VERSION" == 10.2* || "$IOS_VERSION" == 10.1* ]]; then
+            ./bin/kairos to_patch/iBSS.dec to_patch/iBSS.patched
+        elif [[ $IDENTIFIER == iPhone10* ]] && [[ $IOS_VERSION == 14.* || $IOS_VERSION == 15.* || $IOS_VERSION == 16.* ]]; then
+            ./bin/iBoot64Patcher to_patch/iBSS.dec to_patch/iBSS.patched -b "-v wdt=-1" -l -n
+        else
+            ./bin/iBoot64Patcher to_patch/iBSS.dec to_patch/iBSS.patched
+        fi
+        if [[ "$IOS_VERSION" == 10.* || "$IOS_VERSION" == 11.* || "$IOS_VERSION" == 12.* ]]; then
+            echo "Using kairos to patch iBEC instead of iBoot64Patcher"
+            ./bin/kairos to_patch/iBEC.dec to_patch/iBEC.patched -n -b "-v debug=0x09" -c "go" 0x830000300
+        elif [[ "$IOS_VERSION" == 13.* || "$IOS_VERSION" == 14.* || "$IOS_VERSION" == 15.* ]]; then
+            ./bin/iBoot64Patcher to_patch/iBEC.dec to_patch/iBEC.patched -b "-v wdt=-1" -n              
+        else
+            ./bin/iBoot64Patcher to_patch/iBEC.dec to_patch/iBEC.patched -b "rd=disk0s1s1 -v"
+        fi
+        ./bin/img4 -i to_patch/DeviceTree.im4p -o $BOOT_DIR/DeviceTree.img4 -M "$im4m" -T rdtr
+        ./bin/img4 -i to_patch/kernelcache -o $BOOT_DIR/Kernelcache.img4 -M "$im4m" -T rkrn
+        if [[ $IOS_VERSION == 14.* ]]; then
+            ./bin/img4 -i to_patch/kernelcache -o to_patch/kernel.raw
+            ./bin/Kernel64Patcher to_patch/kernel.raw to_patch/kernel.patched -b
+            ./bin/img4 -i to_patch/kernel.patched -o $BOOT_DIR/Kernelcache.img4 -M "$im4m" -A -T rkrn -J || true       
+        fi
+        if [[ $IOS_VERSION == 13.* ]]; then
+            ./bin/img4 -i to_patch/kernelcache -o to_patch/kernel.raw
+            ./bin/Kernel64Patcher to_patch/kernel.raw to_patch/kernel.patched -b13 -n
+            ./bin/img4 -i to_patch/kernel.patched -o $BOOT_DIR/Kernelcache.img4 -M "$im4m" -A -T rkrn -J || true       
+        fi
+        if [[ $IOS_VERSION == 13.* ]] && [[ $IDENTIFIER == iPad5* ]]; then
+            ./bin/img4 -i to_patch/kernelcache -o to_patch/kernel.raw
+            ./bin/Kernel64Patcher to_patch/kernel.raw to_patch/kernel.patched -b13 -n
+            ./bin/kerneldiff to_patch/kernel.raw to_patch/kernel.patched to_patch/kernel.bpatch
+            ./bin/img4 -i to_patch/kernelcache -o $BOOT_DIR/Kernelcache.img4 -M "$im4m" -P to_patch/kernel.bpatch -T rkrn -J || true       
+        fi
+        if [[ $IOS_VERSION == 12.* ]] && [[ $IDENTIFIER == iPad5* ]]; then
+            ./bin/img4 -i to_patch/kernelcache -o to_patch/kernel.raw
+            ./bin/Kernel64Patcher2 to_patch/kernel.raw to_patch/kernel.patched -u 12 --skip-sks --skip-acm --skip-amfi
+            ./bin/kerneldiff to_patch/kernel.raw to_patch/kernel.patched to_patch/kernel.bpatch
+            ./bin/img4 -i to_patch/kernelcache -o $BOOT_DIR/Kernelcache.img4 -M "$im4m" -P to_patch/kernel.bpatch -T rkrn -J || true    
+        fi
+        if [[ $IOS_VERSION == 11.* || $IOS_VERSION == 10.* ]] && [[ $IDENTIFIER == iPad5* ]]; then
+            ./bin/img4 -i to_patch/kernelcache -o to_patch/kernel.raw
+            ./bin/Kernel64Patcher2 to_patch/kernel.raw to_patch/kernel.patched -u 11 --skip-sks --skip-acm --skip-amfi
+            ./bin/kerneldiff to_patch/kernel.raw to_patch/kernel.patched to_patch/kernel.bpatch
+            ./bin/img4 -i to_patch/kernelcache -o $BOOT_DIR/Kernelcache.img4 -M "$im4m" -P to_patch/kernel.bpatch -T rkrn -J || true   
+        fi
+        if [[ $IDENTIFIER == iPhone7* ]] && [[ $IOS_VERSION == 10.* ]]; then
+            ./bin/img4 -i to_patch/kernelcache -o to_patch/kernel.raw
+            ./bin/Kernel64Patcher2 to_patch/kernel.raw to_patch/kernel.patched -u 11 --skip-sks --skip-acm --skip-amfi
+            ./bin/kerneldiff to_patch/kernel.raw to_patch/kernel.patched to_patch/kernel.bpatch
+            ./bin/img4 -i to_patch/kernelcache -o $BOOT_DIR/Kernelcache.img4 -M "$im4m" -P to_patch/kernel.bpatch -T rkrn -J || true   
+        fi
+        if [[ $IOS_VERSION == 15.* ]]; then
+            ./bin/img4 -i to_patch/kernelcache -o to_patch/kernel.raw
+            ./bin/Kernel64Patcher to_patch/kernel.raw to_patch/kernel.patched -e -o -r -b15 
+            ./bin/img4 -i to_patch/kernel.patched -o $BOOT_DIR/Kernelcache.img4 -M "$im4m" -A -T rkrn -J || true    
+        fi
+        if [[ $IOS_VERSION == 15.* ]] && [[ $IDENTIFIER == iPad5* ]]; then
+            ./bin/img4 -i to_patch/kernelcache -o to_patch/kernel.raw
+            ./bin/Kernel64Patcher to_patch/kernel.raw to_patch/kernel.patched -e -o -r -b15
+            ./bin/kerneldiff to_patch/kernel.raw to_patch/kernel.patched to_patch/kernel.bpatch
+            ./bin/img4 -i to_patch/kernelcache -o $BOOT_DIR/Kernelcache.img4 -M "$im4m" -P to_patch/kernel.bpatch -T rkrn -J || true        
+        fi
+        if [[ $IOS_VERSION == 14.* ]] && [[ $IDENTIFIER == iPad5* ]]; then
+            ./bin/img4 -i to_patch/kernelcache -o to_patch/kernel.raw
+            ./bin/Kernel64Patcher to_patch/kernel.raw to_patch/kernel.patched -b
+            ./bin/kerneldiff to_patch/kernel.raw to_patch/kernel.patched to_patch/kernel.bpatch
+            ./bin/img4 -i to_patch/kernelcache -o $BOOT_DIR/Kernelcache.img4 -M "$im4m" -P to_patch/kernel.bpatch -T rkrn -J || true      
+        fi
+        ./bin/img4 -i to_patch/iBSS.patched -o $BOOT_DIR/iBSS.img4 -M "$im4m" -A -T ibss
+        ./bin/img4 -i to_patch/iBEC.patched -o $BOOT_DIR/iBEC.img4 -M "$im4m" -A -T ibec
+        if [[ "$IOS_VERSION" == 12.* || $IOS_VERSION == 13.* || $IOS_VERSION == 14.* || $IOS_VERSION == 15.* ]]; then
+            ./bin/img4 -i to_patch/trustcache -o $BOOT_DIR/Trustcache.img4 -M "$im4m" -T rtsc
+        fi
+        if [[ $IDENTIFIER == iPhone10,3 || $IDENTIFIER == iPhone10,6 ]]; then
+            # camera fix
+            unzip -j "$IPSW_PATH" "Firmware/isp_bni/adc-nike-d22.im4p" -d to_patch
+            ./bin/img4 -i "to_patch/adc-nike-d22.im4p" -o "$BOOT_DIR/isp-firmware.img4" -T ispf -M $im4m
+        fi
+        if [[ $IDENTIFIER == iPhone10,1 || $IDENTIFIER == iPhone10,4 ]]; then
+            # camera fix
+            unzip -j "$IPSW_PATH" "Firmware/isp_bni/adc-nike-d20.im4p" -d to_patch
+            ./bin/img4 -i "to_patch/adc-nike-d20.im4p" -o "$BOOT_DIR/isp-firmware.img4" -T ispf -M $im4m
+        fi
+        if [[ $IDENTIFIER == iPhone10,2 || $IDENTIFIER == iPhone10,5 ]]; then
+            # camera fix
+            unzip -j "$IPSW_PATH" "Firmware/isp_bni/adc-nike-d21.im4p" -d to_patch
+            ./bin/img4 -i "to_patch/adc-nike-d21.im4p" -o "$BOOT_DIR/isp-firmware.img4" -T ispf -M $im4m
+        fi
+        # AVE firmware if on iOS 15.0+
+        if [[ $IDENTIFIER == iPhone10* ]] && [[ $IOS_VERSION == 15.* ]]; then
+            # camera fix
+            unzip -j "$IPSW_PATH" "Firmware/ave/AppleAVE2FW_H10.im4p" -d to_patch
+            ./bin/img4 -i "to_patch/AppleAVE2FW_H10.im4p" -o "$BOOT_DIR/ave-firmware.img4" -T avef -M $im4m
+        fi         
+        if [[ $IDENTIFIER == iPad7* ]] && [[ $IOS_VERSION == 15.* ]]; then
+            # camera fix
+            unzip -j "$IPSW_PATH" "Firmware/ave/AppleAVE2FW_H9.im4p" -d to_patch
+            ./bin/img4 -i "to_patch/AppleAVE2FW_H9.im4p" -o "$BOOT_DIR/ave-firmware.img4" -T avef -M $im4m
+        fi  
+        echo "[*] Verifying generated boot files..."
+
+        require_file "$BOOT_DIR/iBSS.img4"
+        require_file "$BOOT_DIR/iBEC.img4"
+        require_file "$BOOT_DIR/DeviceTree.img4"
+        require_file "$BOOT_DIR/Kernelcache.img4"
+
+        if [[ "$IOS_VERSION" == 12.* || \
+              "$IOS_VERSION" == 13.* || \
+              "$IOS_VERSION" == 14.* || \
+              "$IOS_VERSION" == 15.* ]]; then
+            require_file "$BOOT_DIR/Trustcache.img4"
+        fi
+
+        echo "[*] Boot files created successfully."      
+        rm -rf "to_patch"
+    else
+        echo "[*] Existing boot files found in $BOOT_DIR"
+    fi
+
+    # Placeholder for tethered boot command
+    normal_boot(){
+        
+    echo "[*] Proceeding to tethered boot..."
+    if ! enter_pwndfu_mode; then
+        echo "[!] Device is NOT in PWNDFU mode"
+        echo "[!] You cannot send the bootchain in regular DFU"
+        exit 1
+    fi
+
+    }
+    palera1n_option=0
+    if [[ $IOS_VERSION == 15.* || $IOS_VERSION == 16.* ]] && [[ $dist == 3 || $dist == 4 ]]; then
+        read -p "Would you like to boot jailbroken with palera1n? (y/n): " palera1n_option
+    fi
+    if [[ $palera1n_option == y ]] && [[ $IOS_VERSION == 15.* || $IOS_VERSION == 16.* ]] && [[ $dist == 3 || $dist == 4 ]]; then
+        ./bin/openra1n surrealra1n.sh # placeholder stuff
+    else
+        normal_boot
+    fi
+    ./bin/irecovery -f "$BOOT_DIR/iBSS.img4"
+    if [[ $IDENTIFIER == iPhone10* ]] && [[ $palera1n_option != y ]]; then
+        echo "Your device should now boot."
+        exit 1
+    elif [[ $IDENTIFIER == iPhone10* ]] && [[ $palera1n_option == y ]]; then
+        sleep 3
+        ./bin/palera1n -l -V
+        echo "Your device should now boot."
+        exit 1
+    fi
+    ./bin/irecovery -f "$BOOT_DIR/iBEC.img4"
+    if [[ $IDENTIFIER == iPhone9* || $IDENTIFIER == iPhone10* || $IDENTIFIER == iPad7* ]]; then
+        ./bin/irecovery -c go
+        sleep 6
+    fi
+    ./bin/irecovery -f "$BOOT_DIR/DeviceTree.img4"
+    ./bin/irecovery -c devicetree
+    if [[ "$IOS_VERSION" == 12.* || $IOS_VERSION == 13.* || $IOS_VERSION == 14.* || $IOS_VERSION == 15.* ]]; then
+      ./bin/irecovery -f "$BOOT_DIR/Trustcache.img4"
+      ./bin/irecovery -c firmware
+    fi
+    if [[ $IDENTIFIER == iPhone10,3 || $IDENTIFIER == iPhone10,6 ]]; then
+        ./bin/irecovery -f "$BOOT_DIR/sep-firmware.img4"
+        ./bin/irecovery -c rsepfirmware
+    fi
+    if [[ $IDENTIFIER == iPhone10* ]]; then
+        # Fix camera, flashlight
+        ./bin/irecovery -f "$BOOT_DIR/isp-firmware.img4"
+        ./bin/irecovery -c firmware 
+    fi
+    if [[ $IOS_VERSION == 15.* ]]; then
+        ./bin/irecovery -f "$BOOT_DIR/ave-firmware.img4"
+        ./bin/irecovery -c firmware
+    fi
+    ./bin/irecovery -f "$BOOT_DIR/Kernelcache.img4"
+    ./bin/irecovery -c bootx
+    echo "Your device should now boot."
+    exit 1
+}
+
+main() {
+    bootstrap_environment
+    init_runtime_context
+    cmd_boot "$@"
+}
+
+main "$@"

--- a/scripts/commands/downgrade.sh
+++ b/scripts/commands/downgrade.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+. "$PROJECT_ROOT/scripts/core/lib/bootstrap.sh"
+. "$PROJECT_ROOT/scripts/core/lib/usage.sh"
+. "$PROJECT_ROOT/scripts/core/lib/runtime_context.sh"
+. "$PROJECT_ROOT/scripts/core/lib/command_helpers.sh"
+. "$PROJECT_ROOT/scripts/core/lib/flows.sh"
+
+cmd_downgrade() {
+    normalize_command_args "--downgrade" "$@"
+    local args=("${NORMALIZED_ARGS[@]}")
+
+    if [[ ${#args[@]} -ne 2 ]]; then
+        echo "[!] Usage: --downgrade [IPSW FILE] [SHSH BLOB]"
+        exit 1
+    fi
+    IPSW="${args[0]}"
+    SHSHBLOB="${args[1]}"
+    read -p "What is the iOS version you are downgrading to: " vers
+    if [[ $vers == 10.2* || $vers == 10.1* ]]; then
+        echo "[!] Unsupported currently"
+        exit 1
+    fi
+    echo "[*] Restoring to iOS $vers..."
+    if ! enter_pwndfu_mode; then
+        echo "[!] Device is NOT in PWNDFU mode"
+        echo "[!] Aborting restore. Please re-enter DFU and try again."
+        exit 1
+    fi
+
+    echo "[*] Using SHSH blob: $SHSHBLOB"
+    echo "running futurerestore"
+    if [[ $vers == 11.3* || $vers == 11.4* || $vers == 12.* || $vers == 13.* || $vers == 14.* || $vers == 15.* || $vers == 16.* ]]; then
+       echo "Using latest SEP and baseband!"
+       sudo ./futurerestore/futurerestore -t $SHSHBLOB --use-pwndfu $USE_BASEBAND --latest-sep --no-rsep $IPSW
+    elif [[ $IDENTIFIER == iPhone6* ]] && [[ $vers == 10.1* || $vers == 10.2* || $vers == 10.3* ]]; then
+       echo "iOS 10 SEP needs to be used"
+       IPSW_PATH=$($zenity --file-selection --title="Select the iOS 10.3.3 IPSW file (for SEP firmware)")
+       mkdir tmp
+       mkdir tmp/Firmware
+       mkdir tmp/Firmware/all_flash
+       unzip -j "$IPSW_PATH" "Firmware/all_flash/$SEP" -d tmp/Firmware/all_flash
+       unzip -j "$IPSW_PATH" "Firmware/$BASEBAND10" -d tmp/Firmware
+       SEP_PATH="tmp/Firmware/all_flash/$SEP"
+       BASEBAND_PATH="tmp/Firmware/$BASEBAND10"
+       sudo FUTURERESTORE_I_SOLEMNLY_SWEAR_THAT_I_AM_UP_TO_NO_GOOD=1 ./futurerestore/futurerestore -t $SHSHBLOB --use-pwndfu --no-cache --baseband "$BASEBAND_PATH" --baseband-manifest "$mnifst" --sep "$SEP_PATH" --sep-manifest "$mnifst" --no-rsep $IPSW
+    else
+       echo "SEP is incompatible!"
+       exit 1
+    fi
+    echo "Restore has finished! Read above if there's any errors"
+    echo "Removing tmp folder if it exists"
+    sudo rm -rf "tmp"
+    exit 1
+}
+
+main() {
+    bootstrap_environment
+    init_runtime_context
+    cmd_downgrade "$@"
+}
+
+main "$@"

--- a/scripts/commands/fix_ios8.sh
+++ b/scripts/commands/fix_ios8.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+. "$PROJECT_ROOT/scripts/core/lib/bootstrap.sh"
+. "$PROJECT_ROOT/scripts/core/lib/usage.sh"
+. "$PROJECT_ROOT/scripts/core/lib/runtime_context.sh"
+. "$PROJECT_ROOT/scripts/core/lib/command_helpers.sh"
+. "$PROJECT_ROOT/scripts/core/lib/flows.sh"
+. "$PROJECT_ROOT/scripts/core/lib/ramdisk.sh"
+
+cmd_fix_ios8() {
+    normalize_command_args "--fix-ios8" "$@"
+    local args=("${NORMALIZED_ARGS[@]}")
+
+    if [[ ${#args[@]} -ne 0 ]]; then
+        echo "[!] Usage: --fix-ios8"
+        exit 1
+    fi
+
+    echo "[!] IMPORTANT: Device should be freshly restored to iOS 8.x and not booted yet."
+    echo "[*] Auto-preparing SSH ramdisk and required dependencies for dyld fix..."
+    ensure_ssh_ramdisk_ready
+    echo "[*] SSH ramdisk is ready. Patching dyld cache..."
+    ./bin/sshpass -p "alpine" ssh root@127.0.0.1 -p2222 -o StrictHostKeyChecking=no "/sbin/mount_hfs /dev/disk0s1s1 /mnt1 || true"
+    ./bin/sshpass -p "alpine" scp -P2222 -o StrictHostKeyChecking=no root@localhost:/mnt1/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64 dyld.raw
+    ./bin/dsc64patcher dyld.raw dyld.patched -8
+    ./bin/sshpass -p "alpine" scp -P2222 -o StrictHostKeyChecking=no dyld.patched root@localhost:/mnt1/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64
+    rm -f dyld.patched dyld.raw
+    ./bin/sshpass -p "alpine" ssh root@127.0.0.1 -p2222 -o StrictHostKeyChecking=no "/sbin/reboot || true"
+    echo "dyld fix is complete. You can now boot iOS 8."
+    exit 0
+}
+
+main() {
+    bootstrap_environment
+    init_runtime_context
+    cmd_fix_ios8 "$@"
+}
+
+main "$@"

--- a/scripts/commands/make_custom_ipsw.sh
+++ b/scripts/commands/make_custom_ipsw.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+. "$PROJECT_ROOT/scripts/core/lib/bootstrap.sh"
+. "$PROJECT_ROOT/scripts/core/lib/usage.sh"
+. "$PROJECT_ROOT/scripts/core/lib/runtime_context.sh"
+. "$PROJECT_ROOT/scripts/core/lib/command_helpers.sh"
+. "$PROJECT_ROOT/scripts/core/lib/flows.sh"
+
+cmd_make_custom_ipsw() {
+    normalize_command_args "--make-custom-ipsw" "$@"
+    local args=("${NORMALIZED_ARGS[@]}")
+
+    if [[ ${#args[@]} -ne 3 ]]; then
+        echo "[!] Usage: --make-custom-ipsw [TARGET_IPSW_PATH] [BASE_IPSW_PATH] [iOS_VERSION]"
+        exit 1
+    fi
+    TARGET_IPSW="${args[0]}"
+    BASE_IPSW="${args[1]}"
+    IOS_VERSION="${args[2]}"
+    if [[ "$IDENTIFIER" == iPhone6* ]] && [[ "$IOS_VERSION" == 10.0* || "$IOS_VERSION" == 9.* || "$IOS_VERSION" == 8.* || "$IOS_VERSION" == 7.* ]]; then
+        echo "[!] SEP is incompatible"
+        echo "[!] You cannot restore to this version or make a custom IPSW for it"
+        exit 1
+    fi
+    if [[ "$IDENTIFIER" == iPad4,4 || $IDENTIFIER == iPad4,5 ]] && [[ "$IOS_VERSION" == 10.0* || "$IOS_VERSION" == 9.* || "$IOS_VERSION" == 8.* || "$IOS_VERSION" == 7.* ]]; then
+        echo "[!] SEP is incompatible"
+        echo "[!] You cannot restore to this version or make a custom IPSW for it"
+        exit 1
+    fi
+    if [[ "$IDENTIFIER" == iPad4,6 ]] && [[ "$IOS_VERSION" == 11.2* || "$IOS_VERSION" == 11.1* || "$IOS_VERSION" == 11.0* || "$IOS_VERSION" == 10.* || "$IOS_VERSION" == 9.* || "$IOS_VERSION" == 8.* || "$IOS_VERSION" == 7.* ]]; then
+        echo "[!] SEP is incompatible"
+        echo "[!] You cannot restore to this version or make a custom IPSW for it"
+        exit 1
+    fi
+    if [[ $IDENTIFIER == iPad4,4 || $IDENTIFIER == iPad4,5 || $IDENTIFIER == iPod7* || $IDENTIFIER == iPhone7* || $IDENTIFIER == iPad5* ]] && [[ $IOS_VERSION == 10.1* || $IOS_VERSION == 10.2* ]]; then
+        echo "[!] 10.1-10.2.1 tethered support is not added yet for this device"
+        echo "[!] We may add this support in a future update. For now, please do 10.3 or later"
+        exit 1
+    fi
+    if [[ "$IDENTIFIER" == iPhone6* ]] && [[ "$IOS_VERSION" == 11.2* || "$IOS_VERSION" == 11.1* || "$IOS_VERSION" == 11.0* ]]; then
+        echo "[!] SEP is partially compatible"
+        echo "[!] Restoring to iOS $IOS_VERSION will use iOS 10.3.3 SEP (because iOS 12 SEP is fully incompatible with 11.2.6 and below)"
+        echo "[!] The following issues will occur after the restore: Activation issues, Touch ID not working, unable to connect to password-protected Wi-Fi networks, etc. Device passcode may work though."
+        echo "[!] This is ONLY recommended for advanced users, saving activation tickets with an SSH ramdisk is required before restoring to this version"
+        echo "[!] PLEASE. PLEASE! DO NOT use this to bypass iCloud, only save activation tickets on a device you legally own"
+        read -p "Press enter to continue"
+    fi
+    if [[ $IDENTIFIER == iPhone10* ]] && [[ $IOS_VERSION == 16.6* ]]; then
+        echo "[!] iOS $LATEST_VERSION Cryptex is partially compatible"
+        echo "[!] You will have the following issues:"
+        echo "[!] iMessage/SMS won't work (there is a fix for that in the FutureRestore support Discord Server)"
+        echo "[!] VPN may not work, and potentially other issues"
+        read -p "Press enter to continue"
+    fi
+    if [[ $IDENTIFIER == iPhone10* ]] && [[ $IOS_VERSION == 16.0* || $IOS_VERSION == 16.1* || $IOS_VERSION == 16.2* || $IOS_VERSION == 16.3* || $IOS_VERSION == 16.4* || $IOS_VERSION == 16.5* ]]; then
+        echo "[!] Latest Cryptex is incompatible"
+        echo "You cannot restore or make a custom IPSW for this version."
+        exit 1
+    fi
+    if [[ "$IDENTIFIER" == iPad4,5 || $IDENTIFIER == iPad4,4 ]] && [[ "$IOS_VERSION" == 11.2* || "$IOS_VERSION" == 11.1* || "$IOS_VERSION" == 11.0* ]]; then
+        echo "[!] SEP is partially compatible"
+        echo "[!] Restoring to iOS $IOS_VERSION will use iOS 10.3.3 SEP (because iOS 12 SEP is fully incompatible with 11.2.6 and below)"
+        echo "[!] The following issues will occur after the restore: Activation issues, unable to connect to password-protected Wi-Fi networks, etc. Device passcode may work though."
+        echo "[!] This is ONLY recommended for advanced users, saving activation tickets with an SSH ramdisk is required before restoring to this version"
+        echo "[!] PLEASE. PLEASE! DO NOT use this to bypass iCloud, only save activation tickets on a device you legally own"
+        read -p "Press enter to continue"
+    fi
+    if [[ "$IDENTIFIER" == iPhone7* ]] && [[ "$IOS_VERSION" == 11.2* || "$IOS_VERSION" == 11.1* || "$IOS_VERSION" == 11.0* || "$IOS_VERSION" == 10.0* || "$IOS_VERSION" == 9.* || "$IOS_VERSION" == 8.* ]]; then
+        echo "[!] SEP is incompatible"
+        echo "[!] You cannot restore to this version or make a custom IPSW for it"
+        exit 1
+    fi
+    if [[ $IDENTIFIER == iPod7* || $IDENTIFIER == iPad5,1 || $IDENTIFIER == iPad5,2 || $IDENTIFIER == iPhone7* ]] && [[ $IOS_VERSION == 10.3* ]]; then
+        echo "[!] SEP is compatible, but read the following:"
+        echo "[!] This will use tvOS 10.2.2 SEP from the Apple TV HD."
+        echo "[!] Some device features may or may not break, your mileage may vary."
+        read -p "Press enter to continue"
+    fi
+    if [[ "$IDENTIFIER" == iPod7* ]] && [[ "$IOS_VERSION" == 10.0* || "$IOS_VERSION" == 9.* || "$IOS_VERSION" == 8.* ]]; then
+        echo "[!] SEP is incompatible"
+        echo "[!] You cannot restore to this version or make a custom IPSW for it"
+        exit 1
+    fi
+
+    if [[ "$IDENTIFIER" == iPhone6* ]] && [[ "$IOS_VERSION" == 10.3.3 ]]; then
+        echo "[!] iOS 10.3.3 can be restored untethered via OTA downgrade"
+        echo "[!] It is recommended to use Legacy iOS Kit to downgrade to 10.3.3 untethered (https://github.com/LukeZGD/Legacy-iOS-Kit)"
+        read -p "Press enter to continue with iOS 10.3.3 tethered downgrade"
+    fi
+
+    if [[ "$IDENTIFIER" == iPad7,5 ]] && [[ $IOS_VERSION == 13.4* || $IOS_VERSION == 13.5* || $IOS_VERSION == 13.6* || $IOS_VERSION == 13.7* || $IOS_VERSION == 14.* || $IOS_VERSION == 15.* ]]; then
+        echo "[!] SEP is partially incompatible"
+        echo "[!] The iPadOS $LATEST_VERSION SEP is not fully compatible with this version."
+        echo "[!] The following issues may occur:"
+        echo "[!] On iPadOS 14.0 - 15.7, you will have activation issues. On 15.x, you will also have issues when taking a photo or a video."
+        echo "[!] Sideloading, iMessage, etc. may not work after downgrading with surrealra1n to iPadOS $IOS_VERSION"
+        echo "[!] Touch ID will cease to function fully on 13.x, but it is broken on iPadOS 14-15. And setting a passcode may cause the device to crash."
+        echo "[!] And if you are restoring to iPadOS 13.4 - 13.7, you will be stuck in a blank screen after the restore. Put the device into real DFU mode and boot it normally."
+        echo "[!] It is recommended to use turdus merula instead: https://sep.lol"
+        read -p "Press enter to continue"
+    fi 
+    if [[ "$IDENTIFIER" == iPad5* ]] && [[ $IOS_VERSION == 13.* ]]; then
+        echo "[!] SEP is partially incompatible"
+        echo "[!] The iPadOS $LATEST_VERSION SEP is not fully compatible with this version."
+        echo "[!] The following issues may occur:"
+        echo "[!] Touch ID will cease to function fully."
+        read -p "Press enter to continue"
+    fi 
+    if [[ "$IDENTIFIER" == iPad5* ]] && [[ $IOS_VERSION == 12.* || $IOS_VERSION == 11.4* || $IOS_VERSION == 11.3* ]]; then
+        echo "[!] SEP is partially incompatible"
+        echo "[!] The iPadOS $LATEST_VERSION SEP is not fully compatible with this version."
+        echo "[!] The following issues may occur:"
+        echo "[!] Touch ID will cease to function fully."
+        if [[ $IOS_VERSION == 12.* ]]; then
+            echo "[!] USB accessories will not work, thus you cannot sideload with a PC"
+            echo "[!] To sideload a jailbreak (eg: Chimera, unc0ver), you will need to use https://jailbreaks.app when it is signed."
+        fi
+        read -p "Press enter to continue"
+    fi 
+    if [[ "$IDENTIFIER" == iPad5,3 || $IDENTIFIER == iPad5,4 ]] && [[ $IOS_VERSION == 11.2* || $IOS_VERSION == 11.1* || $IOS_VERSION == 11.0* || $IOS_VERSION == 10.* || $IOS_VERSION == 9.* || $IOS_VERSION == 8.* ]]; then
+        echo "[!] SEP is incompatible"
+        echo "[!] You cannot restore to this version or make a custom IPSW for it"
+        exit 1
+    fi 
+    if [[ "$IDENTIFIER" == iPad7,5 ]] && [[ $IOS_VERSION == 13.3* || $IOS_VERSION == 13.2* || $IOS_VERSION == 13.1* || $IOS_VERSION == 13.0* || $IOS_VERSION == 12.* || $IOS_VERSION == 11.* ]]; then
+        echo "[!] SEP is incompatible"
+        echo "[!] The iPadOS $LATEST_VERSION SEP is not compatible with this version."
+        echo "[!] You MUST use turdus merula instead: https://sep.lol"
+        exit 1
+    fi 
+    if [[ "$IDENTIFIER" == iPhone10* ]] && [[ $IOS_VERSION == 14.* || $IOS_VERSION == 15.* ]]; then
+        echo "[!] SEP is partially incompatible"
+        echo "[!] The following issues may occur:"
+        echo "[!] You will have activation issues, Touch ID resetting (If you have an iPhone X, Face ID will not work), etc."
+        echo "[!] Sideloading, iMessage, etc. may not work after downgrading with surrealra1n to iOS $IOS_VERSION"
+        if [[ $IOS_VERSION == 14.0* || $IOS_VERSION == 14.1* || $IOS_VERSION == 14.2* ]]; then
+            # Additional warnings when restoring 14.0-14.2 on A11 (with 14.3 iBoot method by Nathan)    
+            echo "[!] Additionally, since we are restoring 14.0-14.2, this will have all of the issues of 14.3-15.6.1, but it may have additional issues, especially on versions below 14.2."
+            echo "[!] 14.0-14.2 on A11 MUST use 14.3 iBSS/iBEC to successfully restore and boot."    
+        fi
+        if [[ $IDENTIFIER == iPhone10,2 || $IDENTIFIER == iPhone10,5 || $IDENTIFIER == iPhone10,6 || $IDENTIFIER == iPhone10,3 ]] && [[ $IOS_VERSION == 14.0* || $IOS_VERSION == 14.1* || $IOS_VERSION == 14.2* ]]; then   
+            echo "[!] The 14.3 iBoot method is technically supported on this device, but the custom buildmanifests required for this method do not exist for your device yet!"   
+            echo "[!] A future update will add the required buildmanifests to do this method on iPhone 8 Plus, and X." 
+            exit 1
+        fi
+        read -p "Press enter to continue"
+    fi 
+    if [[ "$IDENTIFIER" == iPhone10* ]] && [[ $IOS_VERSION == 13.* || $IOS_VERSION == 12.* || $IOS_VERSION == 11.* ]]; then
+        echo "[!] SEP is incompatible"
+        echo "[!] You cannot restore to this version or make a custom IPSW for it"
+        exit 1
+    fi 
+    echo "[*] Making custom IPSW..."
+    savedir="restorefiles/$IDENTIFIER/$IOS_VERSION"
+    rm -rf "$savedir"
+    mkdir -p "$savedir"
+    echo ""
+    unzip "$TARGET_IPSW" -d tmp1
+    unzip "$BASE_IPSW" -d tmp2
+    if [[ "$IOS_VERSION" == 10.1* || "$IOS_VERSION" == 10.2* ]] && [[ $IDENTIFIER == iPhone6* ]]; then
+        echo "iOS 10.3 iBSS and iBEC will be used."
+        sudo ./bin/pzb -g Firmware/dfu/$IBSS http://appldnld.apple.com/ios10.3/091-02949-20170327-7584B286-0D86-11E7-A4FA-7ECE122AC769/iPhone_4.0_64bit_10.3_14E277_Restore.ipsw
+        sudo ./bin/pzb -g Firmware/dfu/$IBEC http://appldnld.apple.com/ios10.3/091-02949-20170327-7584B286-0D86-11E7-A4FA-7ECE122AC769/iPhone_4.0_64bit_10.3_14E277_Restore.ipsw
+        rm -rf tmp1/Firmware/dfu/$IBSS10
+        rm -rf tmp1/Firmware/dfu/$IBEC10
+        mv $IBSS tmp1/Firmware/dfu/$IBSS10
+        mv $IBEC tmp1/Firmware/dfu/$IBEC10
+        sudo rm -rf $IBSS
+        sudo rm -rf $IBEC
+    fi
+    if [[ "$IOS_VERSION" == 10.1* || "$IOS_VERSION" == 10.2* ]]; then
+        rm -rf tmp1/Firmware/all_flash/$ALLFLASH/$LLB10
+        rm -rf tmp1/Firmware/all_flash/$ALLFLASH/$IBOOT10
+        cp tmp2/Firmware/all_flash/$LLB tmp1/Firmware/all_flash/$ALLFLASH/$LLB10
+        cp tmp2/Firmware/all_flash/$IBOOT tmp1/Firmware/all_flash/$ALLFLASH/$IBOOT10
+        rm -rf tmp1/BuildManifest.plist
+        cp manifest/$IDENTIFIER/$IOS_VERSION-Manifest.plist tmp1/BuildManifest.plist
+    elif [[ "$IOS_VERSION" == 10.3* ]]; then
+        rm -rf tmp1/Firmware/all_flash/$LLB
+        rm -rf tmp1/Firmware/all_flash/$IBOOT
+        cp tmp2/Firmware/all_flash/$LLB tmp1/Firmware/all_flash/$LLB
+        cp tmp2/Firmware/all_flash/$IBOOT tmp1/Firmware/all_flash/$IBOOT
+    else
+        if [[ $IOS_VERSION == 14.0* || $IOS_VERSION == 14.1* || $IOS_VERSION == 14.2* ]] && [[ $IDENTIFIER == iPhone10* ]]; then
+            # A11 hax to tether restore 14.0-14.2 on 16 SEP, 14.3 iBoot method (thanks to verygenericname for pointing that out)
+            IPSW_PATH=$($zenity --file-selection --title="Select the iOS 14.3 IPSW file (for iBSS and iBEC)")
+            rm -rf tmp1/Firmware/dfu/$IBSS
+            rm -rf tmp1/Firmware/dfu/$IBEC 
+            unzip -j "$IPSW_PATH" "Firmware/dfu/$IBSS" -d tmp1/Firmware/dfu
+            unzip -j "$IPSW_PATH" "Firmware/dfu/$IBEC" -d tmp1/Firmware/dfu
+            # hardcode custom buildmanifest, so it redirects to getting 14.3 keys instead of 14.0-14.2's
+            sudo rm -rf tmp1/BuildManifest.plist
+            cp manifest/$IDENTIFIER/$IOS_VERSION-Manifest.plist tmp1/BuildManifest.plist            
+        fi
+        find tmp1/Firmware/all_flash/ -type f ! -name '*DeviceTree*' -exec rm -f {} +
+        find tmp2/Firmware/all_flash/ -type f ! -name '*DeviceTree*' -exec cp {} tmp1/Firmware/all_flash/ \;
+        if [[ $IOS_VERSION == 11.* || $IOS_VERSION == 12.* || $IOS_VERSION == 13.1* || $IOS_VERSION == 13.2* || $IOS_VERSION == 13.3* ]] && [[ $IDENTIFIER == iPad5* ]]; then
+            sudo ./bin/pzb -g Firmware/all_flash/$DEVICETREE https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+            sudo ./bin/pzb -g $KERNELCACHE https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+            sudo rm -rf "tmp1/Firmware/all_flash/$DEVICETREE"
+            sudo rm -rf "tmp1/$KERNELCACHE"
+            cp $KERNELCACHE "tmp1/$KERNELCACHE"
+            cp $DEVICETREE "tmp1/Firmware/all_flash/$DEVICETREE"
+            sudo rm -rf $KERNELCACHE
+            sudo rm -rf $DEVICETREE
+            smallest_rdskdmg=$(find_dmg tmp1 smallest)
+            update_rdskdmg=$(find_dmg tmp1 largest 1073741824)
+            if [[ $IOS_VERSION == 12.* || $IOS_VERSION == 11.* ]]; then
+                sudo rm -rf $smallest_rdskdmg
+                cd tmp1
+                sudo ../bin/pzb -g 048-64389-366.dmg https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                cd ..
+                sudo rm -rf $update_rdskdmg
+                cd tmp1
+                if [[ $IOS_VERSION == 11.* ]]; then
+                    sudo ../bin/pzb -g BuildManifest.plist https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                    sudo ../bin/pzb -g Firmware/048-64389-366.dmg.trustcache https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw    
+                    sudo ../bin/pzb -g Firmware/048-64500-319.dmg.trustcache https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                    sudo ../bin/pzb -g Firmware/048-65142-364.dmg.trustcache https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                    mv 048-64389-366.dmg.trustcache Firmware/048-64389-366.dmg.trustcache
+                    mv 048-64500-319.dmg.trustcache Firmware/048-64500-319.dmg.trustcache
+                    mv 048-65142-364.dmg.trustcache Firmware/048-65142-364.dmg.trustcache
+                    sudo ../bin/pzb -g Firmware/dfu/$IBSS https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                    sudo ../bin/pzb -g Firmware/dfu/$IBEC https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                    sudo rm -rf Firmware/dfu/$IBSS
+                    sudo rm -rf Firmware/dfu/$IBEC
+                    sudo mv $IBSS Firmware/dfu/$IBSS
+                    sudo mv $IBEC Firmware/dfu/$IBEC
+                    cd ..
+                    root_dmg=$(find_dmg tmp1 largest)
+                    mv $root_dmg tmp1/048-64500-319.dmg
+                    cd tmp1
+                fi
+                sudo ../bin/pzb -g 048-65142-364.dmg https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                cd ..
+            fi
+        fi
+    fi
+    mkdir -p work
+    if [[ "$IDENTIFIER" == iPhone6,* ]] && [[ "$IOS_VERSION" == 10.1* || "$IOS_VERSION" == 10.2* ]]; then
+        cp tmp1/$KERNELCACHE10 work/kernel.orig 
+    else
+        cp tmp1/$KERNELCACHE work/kernel.orig 
+    fi  
+    if [[ $IDENTIFIER == iPhone10,3 || $IDENTIFIER == iPhone10,6 ]] && [[ $IOS_VERSION == 16.* ]]; then
+        # Use latest signed AOP on iOS 16.x restores
+        echo "Replacing AOP firmware"
+        mv tmp2/Firmware/AOP/aopfw-iphone10baop.im4p tmp1/Firmware/AOP/aopfw-iphone10baop.im4p
+    fi
+    if [[ $IDENTIFIER == iPhone10,1 || $IDENTIFIER == iPhone10,4 || $IDENTIFIER == iPhone10,2 || $IDENTIFIER == iPhone10,5 ]] && [[ $IOS_VERSION == 16.* ]]; then
+        # Use latest signed AOP on iOS 16.x restores
+        echo "Replacing AOP firmware"
+        mv tmp2/Firmware/AOP/aopfw-iphone10aop.im4p tmp1/Firmware/AOP/aopfw-iphone10aop.im4p
+    fi
+    rm -rf "tmp2"
+    if [[ $IOS_VERSION == 16.* ]]; then
+        # prepare the localboot stuff, pre-patch kernel-cache
+        ./bin/img4 -i tmp1/$KERNELCACHE -o kernel.raw
+        ./bin/Kernel64Patcher kernel.raw kernel.patched -e -o -h
+        ./bin/img4 -i kernel.patched -o tmp1/$KERNELCACHE -A -T krnl
+    fi
+    if [[ $IOS_VERSION == 15.* ]] && [[ $IDENTIFIER != iPad5* ]]; then
+        # prepare the localboot stuff, pre-patch kernel-cache
+        ./bin/img4 -i tmp1/$KERNELCACHE -o kernel.raw
+        ./bin/Kernel64Patcher kernel.raw kernel.patched -e -o -r -b15
+        ./bin/img4 -i kernel.patched -o tmp1/$KERNELCACHE -A -T krnl
+    fi
+    if [[ $IOS_VERSION == 14.* ]] && [[ $IDENTIFIER != iPad5* ]]; then
+        # prepare the localboot stuff, pre-patch kernel-cache
+        ./bin/img4 -i tmp1/$KERNELCACHE -o kernel.raw
+        ./bin/Kernel64Patcher kernel.raw kernel.patched -b
+        ./bin/img4 -i kernel.patched -o tmp1/$KERNELCACHE -A -T krnl
+    fi
+    cd tmp1
+    zip -0 -r ../custom.ipsw *
+    cd ..
+    mv custom.ipsw "$savedir/custom.ipsw"
+
+    # determine restore ramdisk
+    if [[ $IDENTIFIER == iPhone10,3 || $IDENTIFIER == iPhone10,6 ]]; then
+        # mainly just 16.x stuff
+        restore_ramdisk_dmg="098-08863-001.dmg"
+        update_ramdisk_dmg="098-09105-001.dmg"
+        ipsw_url="https://updates.cdn-apple.com/2022FallFCS/fullrestores/012-65861/0A0400A0-2174-4D49-91B7-43FC9DE24272/iPhone10,3,iPhone10,6_16.0_20A362_Restore.ipsw"
+    fi
+    if [[ $IDENTIFIER == iPhone10,1 || $IDENTIFIER == iPhone10,4 ]]; then
+        # mainly just 16.x stuff
+        restore_ramdisk_dmg="098-08863-001.dmg"
+        update_ramdisk_dmg="098-09105-001.dmg"
+        ipsw_url="https://updates.cdn-apple.com/2022FallFCS/fullrestores/012-65931/BD2515B7-7802-4EB4-9377-98E3238EA5A8/iPhone_4.7_P3_16.0_20A362_Restore.ipsw"
+    fi
+    if [[ $IDENTIFIER == iPhone10,2 || $IDENTIFIER == iPhone10,5 ]]; then
+        # mainly just 16.x stuff
+        restore_ramdisk_dmg="098-08863-001.dmg"
+        update_ramdisk_dmg="098-09105-001.dmg"
+        ipsw_url="https://updates.cdn-apple.com/2022FallFCS/fullrestores/012-65568/0851247C-1B06-4CD4-B3C2-5A94026970B7/iPhone_5.5_P3_16.0_20A362_Restore.ipsw"
+    fi
+    if [[ $IOS_VERSION == 16.* ]]; then
+        # 16.0 ramdisk/kernel, stuff
+        smallest_dmg="$restore_ramdisk_dmg"
+        update_dmg="$update_ramdisk_dmg"
+        sudo ./bin/pzb -g $smallest_dmg $ipsw_url
+        sudo ./bin/pzb -g $update_dmg $ipsw_url
+        sudo ./bin/pzb -g $KERNELCACHE $ipsw_url
+        sudo mv $KERNELCACHE work/kernel.orig
+    else
+        smallest_dmg=$(find_dmg tmp1 smallest)
+        # determine update ramdisk (experimental tethered updates?)
+        update_dmg=$(find_dmg tmp1 largest 1073741824)   
+    fi
+    cd work
+    echo "making patched restore chain"
+    ../bin/img4 -i kernel.orig -o kernel.raw
+    ../bin/KPlooshFinder kernel.raw kernel.patched
+    if [[ $IDENTIFIER == iPad5* || $IDENTIFIER == iPhone7* ]] && [[ $IOS_VERSION == 10.* ]]; then
+        mv kernel.patched kernel.patch
+        ../bin/Kernel64Patcher2 kernel.patch kernel.patched -u 11 --skip-sks --skip-acm --skip-amfi
+    fi
+    ../bin/kerneldiff kernel.raw kernel.patched kernel.bpatch
+    ../bin/img4 -i kernel.orig -o kernel.im4p -T rkrn -P kernel.bpatch -J || true
+    mv kernel.im4p ../$savedir/kernel.im4p
+    # build ramdisk
+    cd ..
+    ./bin/img4 -i "$smallest_dmg" -o ramdisk.raw
+    if [[ "$IOS_VERSION" == 10.* || "$IOS_VERSION" == 11.0* || "$IOS_VERSION" == 11.1* || "$IOS_VERSION" == 11.2* ]]; then
+        echo "growing ramdisk"
+        ./bin/hfsplus ramdisk.raw grow 60000000
+    else
+        echo "skipping ramdisk grow"
+    fi
+    echo "extracting asr to patch"
+    ./bin/hfsplus ramdisk.raw extract usr/sbin/asr 
+    echo "patching asr"
+    ./bin/asr64_patcher asr patched_asr
+    ./bin/ldid -e asr > ents.plist
+    ./bin/ldid -Sents.plist patched_asr
+    echo "replacing asr with patched asr"
+    ./bin/hfsplus ramdisk.raw rm usr/sbin/asr
+    sleep 4
+    ./bin/hfsplus ramdisk.raw add patched_asr usr/sbin/asr
+    sleep 4
+    if [[ "$IOS_VERSION" == 10.* ]]; then
+        ./bin/hfsplus ramdisk.raw chmod 100755 usr/sbin/asr
+    else
+        ./bin/hfsplus ramdisk.raw chmod 755 usr/sbin/asr 
+    fi
+    if [[ $IDENTIFIER == iPhone10,3 || $IDENTIFIER == iPhone10,6 ]]; then
+        echo "Adding ipx patches"
+        sudo ./bin/hfsplus ramdisk.raw extract usr/local/bin/restored_external 
+        ./bin/ipx_restored_patcher restored_external patched_restored_external
+        ./bin/ldid -e restored_external > ents.plist
+        ./bin/ldid -Sents.plist patched_restored_external
+        echo "replacing restored_external with patched restored_external"
+        ./bin/hfsplus ramdisk.raw rm usr/local/bin/restored_external
+        sleep 4 
+        ./bin/hfsplus ramdisk.raw add patched_restored_external usr/local/bin/restored_external
+        sleep 4
+        ./bin/hfsplus ramdisk.raw chmod 755 usr/local/bin/restored_external
+    fi
+    if [[ $IOS_VERSION == 14.* || $IOS_VERSION == 15.* || $IOS_VERSION == 16.* ]]; then
+        # do libimg4 validation patch
+        echo "Doing validation patch so sealing system volume works"
+        sudo ./bin/hfsplus ramdisk.raw extract usr/lib/libimg4.dylib
+        ./bin/libimg4_patcher libimg4.dylib libimg4.patched
+        ./bin/ldid -Sents.plist libimg4.patched
+        sudo ./bin/hfsplus ramdisk.raw rm usr/lib/libimg4.dylib
+        sudo ./bin/hfsplus ramdisk.raw add libimg4.patched usr/lib/libimg4.dylib
+        sudo ./bin/hfsplus ramdisk.raw chmod 755 usr/lib/libimg4.dylib
+    fi
+    sleep 4
+    echo "Packing patched Ramdisk as im4p"
+    ./bin/img4 -i ramdisk.raw -o ramdisk.im4p -T rdsk -A
+    mv ramdisk.im4p $savedir/ramdisk.im4p
+    rm -rf "work"
+    rm -rf asr
+    rm -rf restored_external
+    rm -rf patched_external
+    rm -rf patched_restored_external
+    rm -rf patched_asr
+    rm -rf ents.plist
+    rm -rf ramdisk.raw
+    # build update ramdisk
+    echo "building patched update ramdisk..."
+    ./bin/img4 -i "$update_dmg" -o ramdisk.raw
+    rm -rf "tmp1" 
+    if [[ "$IOS_VERSION" == 10.* || "$IOS_VERSION" == 11.0* || "$IOS_VERSION" == 11.1* || "$IOS_VERSION" == 11.2* ]]; then
+        echo "growing ramdisk"
+        ./bin/hfsplus ramdisk.raw grow 70000000
+    else
+        echo "skipping ramdisk grow"
+    fi
+    echo "extracting asr to patch"
+    ./bin/hfsplus ramdisk.raw extract usr/sbin/asr 
+    echo "patching asr"
+    ./bin/asr64_patcher asr patched_asr
+    ./bin/ldid -e asr > ents.plist
+    ./bin/ldid -Sents.plist patched_asr
+    echo "replacing asr with patched asr"
+    ./bin/hfsplus ramdisk.raw rm usr/sbin/asr
+    sleep 4
+    ./bin/hfsplus ramdisk.raw add patched_asr usr/sbin/asr
+    sleep 4
+    if [[ "$IOS_VERSION" == 10.* ]]; then
+        ./bin/hfsplus ramdisk.raw chmod 100755 usr/sbin/asr
+    else
+        ./bin/hfsplus ramdisk.raw chmod 755 usr/sbin/asr 
+    fi
+    # restored_external in update ramdisk is restored_update
+    if [[ $IDENTIFIER == iPhone10,3 || $IDENTIFIER == iPhone10,6 ]]; then
+        echo "patching restored_update, do ipx patches"
+        ./bin/hfsplus ramdisk.raw extract usr/local/bin/restored_update 
+        ./bin/ipx_restored_patcher restored_update patched_restored_external
+        ./bin/ldid -e restored_update > ents.plist
+        ./bin/ldid -Sents.plist patched_restored_external
+        echo "replacing restored_update with patched restored_update"
+        ./bin/hfsplus ramdisk.raw rm usr/local/bin/restored_update
+        sleep 4 
+        ./bin/hfsplus ramdisk.raw add patched_restored_external usr/local/bin/restored_update
+        sleep 4
+        ./bin/hfsplus ramdisk.raw chmod 755 usr/local/bin/restored_update
+    fi
+    if [[ $IOS_VERSION == 14.* || $IOS_VERSION == 15.* || $IOS_VERSION == 16.* ]]; then
+        # do libimg4 validation patch
+        echo "Doing validation patch so sealing system volume works"
+        sudo ./bin/hfsplus ramdisk.raw extract usr/lib/libimg4.dylib
+        ./bin/libimg4_patcher libimg4.dylib libimg4.patched
+        ./bin/ldid -Sents.plist libimg4.patched
+        sudo ./bin/hfsplus ramdisk.raw rm usr/lib/libimg4.dylib
+        sudo ./bin/hfsplus ramdisk.raw add libimg4.patched usr/lib/libimg4.dylib
+        sudo ./bin/hfsplus ramdisk.raw chmod 755 usr/lib/libimg4.dylib
+    fi
+    sleep 4
+    echo "Packing patched Ramdisk as im4p"
+    ./bin/img4 -i ramdisk.raw -o ramdisk.im4p -T rdsk -A
+    mv ramdisk.im4p $savedir/updateramdisk.im4p
+    rm -rf asr
+    rm -rf restored_update
+    rm -rf patched_external
+    rm -rf patched_restored_external
+    rm -rf patched_asr
+    rm -rf ents.plist
+    rm -rf ramdisk.raw
+    echo "Custom IPSW + patched restore chain has been made! Use --restore $IOS_VERSION to downgrade to the designated firmware"
+    exit 1
+}
+
+main() {
+    bootstrap_environment
+    init_runtime_context
+    cmd_make_custom_ipsw "$@"
+}
+
+main "$@"

--- a/scripts/commands/make_custom_ipsw_2.sh
+++ b/scripts/commands/make_custom_ipsw_2.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+. "$PROJECT_ROOT/scripts/core/lib/bootstrap.sh"
+. "$PROJECT_ROOT/scripts/core/lib/usage.sh"
+. "$PROJECT_ROOT/scripts/core/lib/runtime_context.sh"
+. "$PROJECT_ROOT/scripts/core/lib/command_helpers.sh"
+. "$PROJECT_ROOT/scripts/core/lib/flows.sh"
+
+cmd_make_custom_ipsw_2() {
+    normalize_command_args "--make-custom-ipsw-2" "$@"
+    local args=("${NORMALIZED_ARGS[@]}")
+
+    if [[ ${#args[@]} -ne 3 ]]; then
+        echo "[!] Usage: --make-custom-ipsw-2 [TARGET_IPSW_PATH] [BASE_IPSW_PATH] [iOS_VERSION]"
+        exit 1
+    fi
+    TARGET_IPSW="${args[0]}"
+    BASE_IPSW="${args[1]}"
+    IOS_VERSION="${args[2]}"
+    if [[ $IDENTIFIER != iPad5* ]]; then
+        echo "[!] --make-custom-ipsw-2 is not supported on any other devices than the iPad mini 4, Air 2."
+        echo "[!] Use --make-custom-ipsw instead"
+        exit 1
+    fi
+    if [[ $IDENTIFIER == iPad5* ]] && [[ $IOS_VERSION == 11.2* || $IOS_VERSION == 11.1* || $IOS_VERSION == 11.0* || $IOS_VERSION == 10.* || $IOS_VERSION == 9.* || $IOS_VERSION == 8.* ]]; then
+        echo "[!] SEP is incompatible"
+        echo "[!] You cannot restore or make a custom IPSW for this version."
+        exit 1
+    fi
+    if [[ $IOS_VERSION == 11.* ]]; then
+        KEYS_VERSION="13.4"
+    else
+        KEYS_VERSION="$IOS_VERSION"
+    fi
+    KEY_FILE="keys/$IDENTIFIER.txt"
+    # Extract iBSS and iBEC keys
+    IBSS_KEY=$(read_key_value "$KEY_FILE" "ibss-$KEYS_VERSION")
+    IBEC_KEY=$(read_key_value "$KEY_FILE" "ibec-$KEYS_VERSION")
+    echo "[*] Making custom IPSW..."
+    savedir="restorefiles/$IDENTIFIER/$IOS_VERSION"
+    rm -rf "$savedir"
+    mkdir -p "$savedir"
+    echo ""
+    unzip "$TARGET_IPSW" -d tmp1
+    unzip "$BASE_IPSW" -d tmp2
+    if [[ "$IOS_VERSION" == 10.1* || "$IOS_VERSION" == 10.2* ]] && [[ $IDENTIFIER == iPhone6* ]]; then
+        echo "iOS 10.3 iBSS and iBEC will be used."
+        sudo ./bin/pzb -g Firmware/dfu/$IBSS http://appldnld.apple.com/ios10.3/091-02949-20170327-7584B286-0D86-11E7-A4FA-7ECE122AC769/iPhone_4.0_64bit_10.3_14E277_Restore.ipsw
+        sudo ./bin/pzb -g Firmware/dfu/$IBEC http://appldnld.apple.com/ios10.3/091-02949-20170327-7584B286-0D86-11E7-A4FA-7ECE122AC769/iPhone_4.0_64bit_10.3_14E277_Restore.ipsw
+        rm -rf tmp1/Firmware/dfu/$IBSS10
+        rm -rf tmp1/Firmware/dfu/$IBEC10
+        mv $IBSS tmp1/Firmware/dfu/$IBSS10
+        mv $IBEC tmp1/Firmware/dfu/$IBEC10
+        sudo rm -rf $IBSS
+        sudo rm -rf $IBEC
+    fi
+    if [[ "$IOS_VERSION" == 10.1* || "$IOS_VERSION" == 10.2* ]]; then
+        rm -rf tmp1/Firmware/all_flash/$ALLFLASH/$LLB10
+        rm -rf tmp1/Firmware/all_flash/$ALLFLASH/$IBOOT10
+        cp tmp2/Firmware/all_flash/$LLB tmp1/Firmware/all_flash/$ALLFLASH/$LLB10
+        cp tmp2/Firmware/all_flash/$IBOOT tmp1/Firmware/all_flash/$ALLFLASH/$IBOOT10
+        rm -rf tmp1/BuildManifest.plist
+        cp manifest/$IDENTIFIER/$IOS_VERSION-Manifest.plist tmp1/BuildManifest.plist
+    elif [[ "$IOS_VERSION" == 10.3* ]]; then
+        rm -rf tmp1/Firmware/all_flash/$LLB
+        rm -rf tmp1/Firmware/all_flash/$IBOOT
+        cp tmp2/Firmware/all_flash/$LLB tmp1/Firmware/all_flash/$LLB
+        cp tmp2/Firmware/all_flash/$IBOOT tmp1/Firmware/all_flash/$IBOOT
+    else
+        if [[ $IOS_VERSION == 14.0* || $IOS_VERSION == 14.1* || $IOS_VERSION == 14.2* ]] && [[ $IDENTIFIER == iPhone10* ]]; then
+            # A11 hax to tether restore 14.0-14.2 on 16 SEP, 14.3 iBoot method (thanks to verygenericname for pointing that out)
+            IPSW_PATH=$($zenity --file-selection --title="Select the iOS 14.3 IPSW file (for iBSS and iBEC)")
+            rm -rf tmp1/Firmware/dfu/$IBSS
+            rm -rf tmp1/Firmware/dfu/$IBEC 
+            unzip -j "$IPSW_PATH" "Firmware/dfu/$IBSS" -d tmp1/Firmware/dfu
+            unzip -j "$IPSW_PATH" "Firmware/dfu/$IBEC" -d tmp1/Firmware/dfu
+            # hardcode custom buildmanifest, so it redirects to getting 14.3 keys instead of 14.0-14.2's
+            sudo rm -rf tmp1/BuildManifest.plist
+            cp manifest/$IDENTIFIER/$IOS_VERSION-Manifest.plist tmp1/BuildManifest.plist            
+        fi
+        if [[ $IOS_VERSION == 11.* || $IOS_VERSION == 12.* || $IOS_VERSION == 13.1* || $IOS_VERSION == 13.2* || $IOS_VERSION == 13.3* ]] && [[ $IDENTIFIER == iPad5* ]]; then
+            sudo ./bin/pzb -g Firmware/all_flash/$DEVICETREE https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+            sudo ./bin/pzb -g $KERNELCACHE https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+            sudo rm -rf "tmp1/Firmware/all_flash/$DEVICETREE"
+            sudo rm -rf "tmp1/$KERNELCACHE"
+            cp $KERNELCACHE "tmp1/$KERNELCACHE"
+            cp $DEVICETREE "tmp1/Firmware/all_flash/$DEVICETREE"
+            sudo rm -rf $KERNELCACHE
+            sudo rm -rf $DEVICETREE
+            smallest_rdskdmg=$(find_dmg tmp1 smallest)
+            update_rdskdmg=$(find_dmg tmp1 largest 1073741824)
+            if [[ $IOS_VERSION == 12.* || $IOS_VERSION == 11.* ]]; then
+                sudo rm -rf $smallest_rdskdmg
+                cd tmp1
+                sudo ../bin/pzb -g 048-64389-366.dmg https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                cd ..
+                sudo rm -rf $update_rdskdmg
+                cd tmp1
+                if [[ $IOS_VERSION == 11.* ]]; then
+                    sudo ../bin/pzb -g BuildManifest.plist https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                    sudo ../bin/pzb -g Firmware/048-64389-366.dmg.trustcache https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw    
+                    sudo ../bin/pzb -g Firmware/048-64500-319.dmg.trustcache https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                    sudo ../bin/pzb -g Firmware/048-65142-364.dmg.trustcache https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                    mv 048-64389-366.dmg.trustcache Firmware/048-64389-366.dmg.trustcache
+                    mv 048-64500-319.dmg.trustcache Firmware/048-64500-319.dmg.trustcache
+                    mv 048-65142-364.dmg.trustcache Firmware/048-65142-364.dmg.trustcache
+                    sudo ../bin/pzb -g Firmware/dfu/$IBSS https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                    sudo ../bin/pzb -g Firmware/dfu/$IBEC https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                    sudo rm -rf Firmware/dfu/$IBSS
+                    sudo rm -rf Firmware/dfu/$IBEC
+                    sudo mv $IBSS Firmware/dfu/$IBSS
+                    sudo mv $IBEC Firmware/dfu/$IBEC
+                    cd ..
+                    root_dmg=$(find_dmg tmp1 largest)
+                    mv $root_dmg tmp1/048-64500-319.dmg
+                    cd tmp1
+                fi
+                sudo ../bin/pzb -g 048-65142-364.dmg https://updates.cdn-apple.com/2020WinterFCS/fullrestores/041-42831/7341A77D-6526-4C64-8753-D886106F97CD/iPad_64bit_TouchID_13.4_17E255_Restore.ipsw
+                cd ..
+            fi
+        fi
+    fi
+
+    # determine restore ramdisk
+    smallest_dmg=$(find_dmg tmp1 smallest)
+    # determine update ramdisk (experimental tethered updates?)
+    update_dmg=$(find_dmg tmp1 largest 1073741824)
+    # determine restore ramdisk final destination
+    smallest_dmg_2=$(find_dmg tmp2 smallest)
+    # determine update ramdisk final destination
+    update_dmg_2=$(find_dmg tmp2 largest 1073741824)
+    # determine root filesystem 
+    root_dmg_path=$(find_dmg tmp1 largest)
+    # determine root filesystem final destination
+    root_dmg_path_2=$(find_dmg tmp2 largest)
+    rm -rf $root_dmg_path_2
+    mv $root_dmg_path $root_dmg_path_2
+    rm -rf tmp2/Firmware/all_flash/$DEVICETREE
+    mv tmp1/Firmware/all_flash/$DEVICETREE tmp2/Firmware/all_flash/$DEVICETREE
+    echo "Patching iBSS"
+    mkdir -p work
+    ./bin/img4 -i tmp1/Firmware/dfu/$IBSS -o work/iBSS.raw -k $IBSS_KEY
+    ./bin/iBoot64Patcher work/iBSS.raw work/iBSS.patched
+    ./bin/img4 -i work/iBSS.patched -o tmp2/Firmware/dfu/$IBSS -A -T ibss
+    echo "Patching iBEC"
+    ./bin/img4 -i tmp1/Firmware/dfu/$IBEC -o work/iBEC.raw -k $IBEC_KEY
+    ./bin/iBoot64Patcher work/iBEC.raw work/iBEC.patched
+    ./bin/img4 -i work/iBEC.patched -o tmp2/Firmware/dfu/$IBEC -A -T ibec
+    if [[ "$IDENTIFIER" == iPhone6,* ]] && [[ "$IOS_VERSION" == 10.1* || "$IOS_VERSION" == 10.2* ]]; then
+        cp tmp1/$KERNELCACHE10 work/kernel.orig 
+    else
+        cp tmp1/$KERNELCACHE work/kernel.orig 
+    fi     
+    cd work
+    echo "making patched restore chain"
+    ../bin/img4 -i kernel.orig -o kernel.raw
+    ../bin/KPlooshFinder kernel.raw kernel.patched
+    ../bin/kerneldiff kernel.raw kernel.patched kernel.bpatch
+    ../bin/img4 -i kernel.orig -o kernel.im4p -T rkrn -P kernel.bpatch -J || true
+    mv kernel.im4p ../tmp2/$KERNELCACHE
+    # build ramdisk
+    cd ..
+    ./bin/img4 -i "$smallest_dmg" -o ramdisk.raw
+    if [[ "$IDENTIFIER" == iPhone6,* || $IDENTIFIER == iPod7* || $IDENTIFIER == iPad4* ]] && [[ "$IOS_VERSION" == 10.* || "$IOS_VERSION" == 11.0* || "$IOS_VERSION" == 11.1* || "$IOS_VERSION" == 11.2* ]]; then
+        echo "growing ramdisk"
+        ./bin/hfsplus ramdisk.raw grow 60000000
+    else
+        echo "skipping ramdisk grow"
+    fi
+    echo "extracting asr to patch"
+    ./bin/hfsplus ramdisk.raw extract usr/sbin/asr 
+    echo "patching asr"
+    ./bin/asr64_patcher asr patched_asr
+    ./bin/ldid -e asr > ents.plist
+    ./bin/ldid -Sents.plist patched_asr
+    echo "replacing asr with patched asr"
+    ./bin/hfsplus ramdisk.raw rm usr/sbin/asr
+    sleep 4
+    ./bin/hfsplus ramdisk.raw add patched_asr usr/sbin/asr
+    sleep 4
+    if [[ "$IDENTIFIER" == iPhone6,* || $IDENTIFIER == iPad4* ]] && [[ "$IOS_VERSION" == 10.* ]]; then
+        ./bin/hfsplus ramdisk.raw chmod 100755 usr/sbin/asr
+    else
+        ./bin/hfsplus ramdisk.raw chmod 755 usr/sbin/asr 
+    fi
+    if [[ $IOS_VERSION == 14.* || $IOS_VERSION == 15.* ]]; then
+        echo "patching restored_external"
+        sudo ./bin/hfsplus ramdisk.raw extract usr/local/bin/restored_external 
+        if [[ $IDENTIFIER == iPhone10,3 || $IDENTIFIER == iPhone10,6 ]]; then
+            echo "[!] You are trying to restore an iPhone X to iOS $IOS_VERSION"
+            echo "An additional patch is required!"
+            ./bin/ipx_restored_patcher restored_external patched_external
+            ./bin/restored_external64_patcher patched_external patched_restored_external
+        else
+            ./bin/restored_external64_patcher restored_external patched_restored_external
+        fi
+        ./bin/ldid -e restored_external > ents.plist
+        ./bin/ldid -Sents.plist patched_restored_external
+        echo "replacing restored_external with patched restored_external"
+        ./bin/hfsplus ramdisk.raw rm usr/local/bin/restored_external
+        sleep 4 
+        ./bin/hfsplus ramdisk.raw add patched_restored_external usr/local/bin/restored_external
+        sleep 4
+        ./bin/hfsplus ramdisk.raw chmod 755 usr/local/bin/restored_external
+    fi
+    sleep 4
+    echo "Packing patched Ramdisk as im4p"
+    ./bin/img4 -i ramdisk.raw -o $smallest_dmg_2 -T rdsk -A
+    rm -rf "work"
+    rm -rf asr
+    rm -rf restored_external
+    rm -rf patched_external
+    rm -rf patched_restored_external
+    rm -rf patched_asr
+    rm -rf ents.plist
+    rm -rf ramdisk.raw
+    # build update ramdisk
+    echo "building patched update ramdisk..."
+    ./bin/img4 -i "$update_dmg" -o ramdisk.raw
+    if [[ "$IDENTIFIER" == iPhone6,* || $IDENTIFIER == iPod7* || $IDENTIFIER == iPad4* ]] && [[ "$IOS_VERSION" == 10.* || "$IOS_VERSION" == 11.0* || "$IOS_VERSION" == 11.1* || "$IOS_VERSION" == 11.2* ]]; then
+        echo "growing ramdisk"
+        ./bin/hfsplus ramdisk.raw grow 70000000
+    else
+        echo "skipping ramdisk grow"
+    fi
+    echo "extracting asr to patch"
+    ./bin/hfsplus ramdisk.raw extract usr/sbin/asr 
+    echo "patching asr"
+    ./bin/asr64_patcher asr patched_asr
+    ./bin/ldid -e asr > ents.plist
+    ./bin/ldid -Sents.plist patched_asr
+    echo "replacing asr with patched asr"
+    ./bin/hfsplus ramdisk.raw rm usr/sbin/asr
+    sleep 4
+    ./bin/hfsplus ramdisk.raw add patched_asr usr/sbin/asr
+    sleep 4
+    if [[ "$IDENTIFIER" == iPhone6,* || $IDENTIFIER == iPad4* ]] && [[ "$IOS_VERSION" == 10.* ]]; then
+        ./bin/hfsplus ramdisk.raw chmod 100755 usr/sbin/asr
+    else
+        ./bin/hfsplus ramdisk.raw chmod 755 usr/sbin/asr 
+    fi
+    # restored_external in update ramdisk is restored_update
+    if [[ $IOS_VERSION == 14.* || $IOS_VERSION == 15.* ]]; then
+        echo "patching restored_update"
+        ./bin/hfsplus ramdisk.raw extract usr/local/bin/restored_update 
+        if [[ $IDENTIFIER == iPhone10,3 || $IDENTIFIER == iPhone10,6 ]]; then
+            echo "[!] You are trying to restore an iPhone X to iOS $IOS_VERSION"
+            echo "An additional patch is required!"
+            ./bin/ipx_restored_patcher restored_update patched_external
+            ./bin/restored_external64_patcher patched_external patched_restored_external
+        else
+            ./bin/restored_external64_patcher restored_update patched_restored_external
+        fi
+        ./bin/ldid -e restored_update > ents.plist
+        ./bin/ldid -Sents.plist patched_restored_external
+        echo "replacing restored_update with patched restored_update"
+        ./bin/hfsplus ramdisk.raw rm usr/local/bin/restored_update
+        sleep 4 
+        ./bin/hfsplus ramdisk.raw add patched_restored_external usr/local/bin/restored_update
+        sleep 4
+        ./bin/hfsplus ramdisk.raw chmod 755 usr/local/bin/restored_update
+    fi
+    sleep 4
+    echo "Packing patched Ramdisk as im4p"
+    ./bin/img4 -i ramdisk.raw -o $update_dmg_2 -T rdsk -A
+    rm -rf asr
+    rm -rf restored_update
+    rm -rf patched_external
+    rm -rf patched_restored_external
+    rm -rf patched_asr
+    rm -rf ents.plist
+    rm -rf ramdisk.raw
+    rm -rf "tmp1"
+    cd tmp2
+    zip -0 -r ../custom.ipsw *
+    cd ..
+    mv custom.ipsw "$savedir/custom.ipsw"
+    rm -rf "tmp2"
+    rm -rf "$savedir/ramdisk.im4p"
+    rm -rf "$savedir/updateramdisk.im4p"
+    rm -rf "$savedir/kernel.im4p"
+    echo "Custom IPSW + patched restore chain has been made! Use --restore $IOS_VERSION to downgrade to the designated firmware"
+    exit 1
+}
+
+main() {
+    bootstrap_environment
+    init_runtime_context
+    cmd_make_custom_ipsw_2 "$@"
+}
+
+main "$@"

--- a/scripts/commands/restore.sh
+++ b/scripts/commands/restore.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+. "$PROJECT_ROOT/scripts/core/lib/bootstrap.sh"
+. "$PROJECT_ROOT/scripts/core/lib/usage.sh"
+. "$PROJECT_ROOT/scripts/core/lib/runtime_context.sh"
+. "$PROJECT_ROOT/scripts/core/lib/command_helpers.sh"
+. "$PROJECT_ROOT/scripts/core/lib/flows.sh"
+
+cmd_restore() {
+    normalize_command_args "--restore" "$@"
+    local args=("${NORMALIZED_ARGS[@]}")
+
+    if [[ ${#args[@]} -ne 1 ]]; then
+        echo "[!] Usage: --restore [iOS_VERSION]"
+        exit 1
+    fi
+    sudo rm -rf "shsh"
+    IOS_VERSION="${args[0]}"
+    echo "[*] Restoring to iOS $IOS_VERSION..."
+    restoredir="restorefiles/$IDENTIFIER/$IOS_VERSION"
+    echo "Fetching shsh blobs for iOS $LATEST_VERSION, this is just so it will restore. skip-blob flag is used"
+    mkdir -p shsh
+    sudo ./bin/tsschecker -d $IDENTIFIER -s -e $ECID -i $LATEST_VERSION --save-path shsh
+
+    # Find the .shsh2 file in the shsh directory
+    shshpath=$(require_shsh_blob "shsh")
+
+    echo "[*] Using SHSH blob: $shshpath"
+    read -p "Do you want to do an update install? (y/n): " update_prompt
+    if [[ $IDENTIFIER == iPhone10* || $IDENTIFIER == iPad7* ]] && [[ $IOS_VERSION == 14.* || $IOS_VERSION == 15.* ]] && [[ $update_prompt == N || $update_prompt == n ]]; then
+        echo "We must save activation tickets in order to activate on this version. Please read what is below."
+        echo "Please read this guide to backup/restore activation tickets: https://gist.github.com/pixdoet/2b58cce317a3bc7158dfe10c53e3dd32"
+    fi
+    if [[ $IOS_VERSION == 11.0* || $IOS_VERSION == 11.1* || $IOS_VERSION == 11.2* ]] && [[ $update_prompt == N || $update_prompt == n ]]; then
+        echo "We must save activation tickets in order to activate on this version. Please read what is below."
+        echo "Please read this guide to backup/restore activation tickets: https://gist.github.com/pixdoet/2b58cce317a3bc7158dfe10c53e3dd32"
+    fi
+    if enter_pwndfu_mode 1; then
+        echo "[*] Device is in PWNDFU mode"
+        if [[ $IDENTIFIER == iPhone10,3 || $IDENTIFIER == iPhone10,6 ]]; then
+            ./bin/irecovery -f surrealra1n.sh
+            ./bin/gaster reset
+        fi
+    else
+        echo "[!] Device is NOT in PWNDFU mode"
+        echo "[!] Aborting restore. Please re-enter DFU and try again."
+        exit 1
+    fi
+    if [[ $update_prompt == y || $update_prompt == Y ]]; then
+        INSTALL_TYPE="--update"
+    else
+        INSTALL_TYPE=""
+    fi
+    # Check if IPSW is a make-custom-ipsw-2 ipsw or not.
+    if [[ -f "$restoredir/kernel.im4p" && \
+          -f "$restoredir/updateramdisk.im4p" && \
+          -f "$restoredir/ramdisk.im4p" ]]; then
+        echo "This is not a make-custom-ipsw-2 ipsw. Will use futurerestore."
+    else
+        echo "This is a make-custom-ipsw-2 IPSW. Will do custom restore method"
+        sudo rm -rf "shsh"
+        echo "Fetching shsh blobs for iOS $LATEST_VERSION, this is just so it will restore. skip-blob flag is used"
+        mkdir -p shsh
+        APNONCE=$(./bin/irecovery -q | grep "^NONC:" | cut -d ':' -f2 | xargs)
+        sudo ./bin/tsschecker -d $IDENTIFIER -s -e $ECID -i $LATEST_VERSION --save-path shsh --apnonce $APNONCE
+
+        # Find the .shsh2 file in the shsh directory
+        shshpath2=$(find shsh -type f -name "*.shsh2" | head -n 1)
+        if [[ -z "$shshpath2" ]]; then
+            echo "[!] No .shsh2 blob found in shsh folder. Aborting."
+            exit 1
+        fi
+        unzip -j "$restoredir/custom.ipsw" "Firmware/dfu/$IBSS" -d tmp
+        unzip -j "$restoredir/custom.ipsw" "Firmware/dfu/$IBEC" -d tmp
+        ./bin/img4tool -e -s $shshpath2 -m im4m
+        ./bin/img4 -i tmp/$IBSS -o tmp/iBSS.img4 -M im4m -T ibss
+        ./bin/img4 -i tmp/$IBEC -o tmp/iBEC.img4 -M im4m -T ibec
+        ./bin/irecovery -f tmp/iBSS.img4
+        ./bin/irecovery -f tmp/iBEC.img4
+        echo "Checking if device is in Recovery mode"
+        MODE=$(./bin/irecovery -q | grep "^MODE:" | cut -d ':' -f2 | xargs)
+        if [[ $MODE == Recovery ]]; then
+            echo "Device is in recovery mode"
+            sleep 1
+        else
+            echo "Device not detected in Recovery, aborting"
+            rm -rf "tmp"
+            exit 1
+        fi
+        sudo ./futurerestore/futurerestore -t $shshpath2 $USE_BASEBAND --latest-sep --no-rsep $INSTALL_TYPE $restoredir/custom.ipsw
+        rm -rf "tmp"
+        echo "Restore has finished! Read above if there's any errors"
+        exit 1
+    fi
+
+    # Potential future iOS 16.x tethered support, send rsep always if restoring iPhone X to fix FDR SEP panic
+    if [[ $IOS_VERSION == 16.* || $IDENTIFIER == iPhone10,3 || $IDENTIFIER == iPhone10,6 ]]; then
+        use_rsep=""
+    else
+        use_rsep="--no-rsep"
+    fi
+    echo "running futurerestore"
+    if [[ "$IDENTIFIER" == iPhone6,* || $IDENTIFIER == iPod7* || $IDENTIFIER == iPad4* || $IDENTIFIER == iPhone7* || $IDENTIFIER == iPad5,1 || $IDENTIFIER == iPad5,2 ]] && [[ "$IOS_VERSION" == 10.* || "$IOS_VERSION" == 11.0* || "$IOS_VERSION" == 11.1* || "$IOS_VERSION" == 11.2* ]]; then
+        echo "iOS 10 sep will be used"
+        if [[ $IDENTIFIER == iPhone6* ]]; then
+            sudo ./bin/pzb -g Firmware/all_flash/$SEP http://appldnld.apple.com/ios10.3.3/091-23133-20170719-CA8E78E6-6977-11E7-968B-2B9100BA0AE3/iPhone_4.0_64bit_10.3.3_14G60_Restore.ipsw
+        fi
+        if [[ $IDENTIFIER == iPad4,4 || $IDENTIFIER == iPad4,5 ]]; then
+            sudo ./bin/pzb -g Firmware/all_flash/$SEP http://appldnld.apple.com/ios10.3.3/091-23378-20170719-CA983C78-6977-11E7-8922-3D9100BA0AE3/iPad_64bit_10.3.3_14G60_Restore.ipsw
+        fi
+        if [[ $IDENTIFIER == iPod7* ]]; then
+            # download tvOS SEP
+            SEP="sep-firmware.j42d.RELEASE.im4p"
+            sudo ./bin/pzb -g Firmware/all_flash/$SEP https://secure-appldnld.apple.com/tvos10.2.2/091-23452-20170720-5D53229C-6A56-11E7-8577-8B2C4A4DD6D5/AppleTV5,3_10.2.2_14W756_Restore.ipsw
+            mnifst="manifest/BuildManifest-iPod7,1.plist" # slightly modified BuildManifest from tvOS 10.2.2 to hack signed SEP for 10.3.x restores A8
+        fi
+        if [[ $IDENTIFIER == iPhone7,2 ]]; then
+            SEP="sep-firmware.j42d.RELEASE.im4p"
+            sudo ./bin/pzb -g Firmware/all_flash/$SEP https://secure-appldnld.apple.com/tvos10.2.2/091-23452-20170720-5D53229C-6A56-11E7-8577-8B2C4A4DD6D5/AppleTV5,3_10.2.2_14W756_Restore.ipsw
+            mnifst="manifest/BuildManifest-iPhone7,2.plist"
+            curl -L -o $mnifst https://github.com/pwnerblu/cursed-sep-resources/raw/refs/heads/main/BuildManifest-iPhone7,2.plist
+        fi
+        if [[ $IDENTIFIER == iPhone7,1 ]]; then
+            SEP="sep-firmware.j42d.RELEASE.im4p"
+            sudo ./bin/pzb -g Firmware/all_flash/$SEP https://secure-appldnld.apple.com/tvos10.2.2/091-23452-20170720-5D53229C-6A56-11E7-8577-8B2C4A4DD6D5/AppleTV5,3_10.2.2_14W756_Restore.ipsw
+            mnifst="manifest/BuildManifest-iPhone7,1.plist"
+            curl -L -o $mnifst https://github.com/pwnerblu/cursed-sep-resources/raw/refs/heads/main/BuildManifest-iPhone7,1.plist
+        fi
+        if [[ $IDENTIFIER == iPad5,1 ]]; then
+            SEP="sep-firmware.j42d.RELEASE.im4p"
+            sudo ./bin/pzb -g Firmware/all_flash/$SEP https://secure-appldnld.apple.com/tvos10.2.2/091-23452-20170720-5D53229C-6A56-11E7-8577-8B2C4A4DD6D5/AppleTV5,3_10.2.2_14W756_Restore.ipsw
+            mnifst="manifest/BuildManifest-iPad5,1.plist"
+            curl -L -o $mnifst https://github.com/pwnerblu/cursed-sep-resources/raw/refs/heads/main/BuildManifest-iPad5,1.plist
+        fi
+        if [[ $IDENTIFIER == iPad5,2 ]]; then
+            SEP="sep-firmware.j42d.RELEASE.im4p"
+            sudo ./bin/pzb -g Firmware/all_flash/$SEP https://secure-appldnld.apple.com/tvos10.2.2/091-23452-20170720-5D53229C-6A56-11E7-8577-8B2C4A4DD6D5/AppleTV5,3_10.2.2_14W756_Restore.ipsw
+            mnifst="manifest/BuildManifest-iPad5,2.plist"
+            curl -L -o $mnifst https://github.com/pwnerblu/cursed-sep-resources/raw/refs/heads/main/BuildManifest-iPad5,2.plist
+        fi
+        mkdir tmp
+        mkdir tmp/Firmware
+        mkdir tmp/Firmware/all_flash
+        mv $SEP tmp/Firmware/all_flash/
+        SEP_PATH="tmp/Firmware/all_flash/$SEP"
+        if [[ $IOS_VERSION == 11.0* || $IOS_VERSION == 11.1* || $IOS_VERSION == 11.2* ]]; then
+            if [[ $update_prompt == y || $update_prompt == Y ]]; then
+                sudo FUTURERESTORE_I_SOLEMNLY_SWEAR_THAT_I_AM_UP_TO_NO_GOOD=1 ./futurerestore/futurerestore -t $shshpath --skip-blob --use-pwndfu --no-cache --rdsk $restoredir/updateramdisk.im4p --rkrn $restoredir/kernel.im4p $USE_BASEBAND --sep "$SEP_PATH" --sep-manifest "$mnifst" --no-rsep $restoredir/custom.ipsw
+                echo "Restore has finished! Read above if there's any errors"
+                echo "YOU WILL FACE A LOT OF ISSUES REGARDING STUFF THAT REQUIRES SEP TO FULLY WORK"
+                exit 1
+            fi
+            sudo FUTURERESTORE_I_SOLEMNLY_SWEAR_THAT_I_AM_UP_TO_NO_GOOD=1 ./futurerestore/futurerestore -t $shshpath --skip-blob --use-pwndfu --rdsk $restoredir/ramdisk.im4p --rkrn $restoredir/kernel.im4p --no-cache $USE_BASEBAND --sep "$SEP_PATH" --sep-manifest "$mnifst" --no-rsep $restoredir/custom.ipsw
+            rm -rf "tmp"
+            echo "Restore has finished! Read above if there's any errors"
+            echo "YOU WILL FACE A LOT OF ISSUES REGARDING STUFF THAT REQUIRES SEP TO FULLY WORK"
+            exit 1
+        fi
+        if [[ $update_prompt == y || $update_prompt == Y ]]; then
+            sudo FUTURERESTORE_I_SOLEMNLY_SWEAR_THAT_I_AM_UP_TO_NO_GOOD=1 ./futurerestore/futurerestore -t $shshpath --skip-blob --use-pwndfu --no-cache --rdsk $restoredir/updateramdisk.im4p --rkrn $restoredir/kernel.im4p $USE_BASEBAND --sep "$SEP_PATH" --sep-manifest "$mnifst" --no-rsep $restoredir/custom.ipsw
+            echo "Restore has finished! Read above if there's any errors"
+            exit 1
+        fi
+        sudo FUTURERESTORE_I_SOLEMNLY_SWEAR_THAT_I_AM_UP_TO_NO_GOOD=1 ./futurerestore/futurerestore -t $shshpath --skip-blob --use-pwndfu --rdsk $restoredir/ramdisk.im4p --rkrn $restoredir/kernel.im4p --no-cache $USE_BASEBAND --sep "$SEP_PATH" --sep-manifest "$mnifst" --no-rsep $restoredir/custom.ipsw
+        rm -rf "tmp"
+        echo "Restore has finished! Read above if there's any errors"
+        exit 1
+    else
+        if [[ $update_prompt == y || $update_prompt == Y ]]; then
+            sudo ./futurerestore/futurerestore -t $shshpath --skip-blob --use-pwndfu --no-cache --rdsk $restoredir/updateramdisk.im4p --rkrn $restoredir/kernel.im4p $USE_BASEBAND --latest-sep $use_rsep $restoredir/custom.ipsw
+            echo "Restore has finished! Read above if there's any errors"
+            if [[ $IDENTIFIER == iPad5* || $IDENTIFIER == iPad7* || $IDENTIFIER == iPhone10* ]]; then
+                sudo rm -rf "boot/$IDENTIFIER/$IOS_VERSION"
+            fi
+            exit 1
+        fi
+        sudo ./futurerestore/futurerestore -t $shshpath --skip-blob --use-pwndfu --no-cache --rdsk $restoredir/ramdisk.im4p --rkrn $restoredir/kernel.im4p $USE_BASEBAND --latest-sep $use_rsep $restoredir/custom.ipsw 
+    fi
+    echo "Restore has finished! Read above if there's any errors"
+    if [[ $IDENTIFIER == iPad5* || $IDENTIFIER == iPad7* || $IDENTIFIER == iPhone10* ]]; then
+        sudo rm -rf "boot/$IDENTIFIER/$IOS_VERSION"
+    fi
+    exit 1
+}
+
+main() {
+    bootstrap_environment
+    init_runtime_context
+    cmd_restore "$@"
+}
+
+main "$@"

--- a/scripts/commands/seprmvr64_boot.sh
+++ b/scripts/commands/seprmvr64_boot.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+. "$PROJECT_ROOT/scripts/core/lib/bootstrap.sh"
+. "$PROJECT_ROOT/scripts/core/lib/usage.sh"
+. "$PROJECT_ROOT/scripts/core/lib/runtime_context.sh"
+. "$PROJECT_ROOT/scripts/core/lib/command_helpers.sh"
+. "$PROJECT_ROOT/scripts/core/lib/flows.sh"
+
+cmd_seprmvr64_boot() {
+    normalize_command_args "--seprmvr64-boot" "$@"
+    local args=("${NORMALIZED_ARGS[@]}")
+
+    if [[ ${#args[@]} -ne 1 ]]; then
+        echo "[!] Usage: --seprmvr64-boot [iOS_VERSION]"
+        exit 1
+    fi
+    IOS_VERSION="${args[0]}"
+    savedir="seprmvr64boot/$IDENTIFIER/$IOS_VERSION"
+    shshpath=$(require_shsh_blob "shsh")
+    if [[ ! -d "$savedir" ]] || [[ ! -f "$savedir"/iBSS.img4 || ! -f "$savedir"/iBEC.img4 || ! -f "$savedir"/DeviceTree.img4 || ! -f "$savedir"/Kernelcache.img4 ]]; then
+        echo "[!] New boot files must be created."
+        IPSW_PATH=$($zenity --file-selection --title="Select the iOS $IOS_VERSION IPSW file")
+        sleep 2
+    else
+        if ! enter_pwndfu_mode 1; then
+            echo "[!] Device is NOT in PWNDFU mode"
+            echo "[!] Aborting boot process. Please re-enter DFU and try again."
+            exit 1
+        fi
+        ./bin/irecovery -f $savedir/iBSS.img4
+        ./bin/irecovery -f $savedir/iBEC.img4
+        ./bin/irecovery -f $savedir/DeviceTree.img4
+        ./bin/irecovery -c devicetree
+        ./bin/irecovery -f $savedir/Kernelcache.img4
+        ./bin/irecovery -c bootx
+        echo "Your device should now boot."
+        exit 0
+    fi
+    if [[ -z "$IPSW_PATH" ]]; then
+        echo "[!] No IPSW selected. Aborting."
+        exit 1
+    fi
+    if [[ ! -f "$IPSW_PATH" ]]; then
+        echo "[!] IPSW does not exist: $IPSW_PATH"
+        exit 1
+    fi
+    rm -rf "$savedir"
+    mkdir -p "$savedir"
+    echo ""
+    unzip "$IPSW_PATH" -d tmp1
+    # Read decryption keys
+    KEY_FILE="keys/$IDENTIFIER.txt"
+    if [[ ! -f "$KEY_FILE" ]]; then
+        echo "[!] Key file $KEY_FILE not found. Aborting."
+        exit 1
+    fi
+    ./bin/img4tool -s "$shshpath" -e -m "$IDENTIFIER-im4m"
+    im4m="$IDENTIFIER-im4m"
+
+    # Extract iBSS and iBEC keys
+    IBSS_KEY=$(read_key_value "$KEY_FILE" "ibss-$IOS_VERSION")
+    IBEC_KEY=$(read_key_value "$KEY_FILE" "ibec-$IOS_VERSION")
+    DTRE_KEY=$(read_key_value "$KEY_FILE" "dtre-$IOS_VERSION")
+    KRNL_KEY=$(read_key_value "$KEY_FILE" "krnl-$IOS_VERSION")
+
+    if [[ -z "$IBSS_KEY" || -z "$IBEC_KEY" ]]; then
+        echo "[!] Missing iBSS or iBEC key for iOS $IOS_VERSION in $KEY_FILE. Aborting."
+        exit 1
+    fi
+
+    echo "[*] Found keys:"
+    echo "    iBSS Key: $IBSS_KEY"
+    echo "    iBEC Key: $IBEC_KEY"
+    mkdir -p work
+    ./bin/img4 -i "tmp1/Firmware/all_flash/$ALLFLASH/$DEVICETREE" -o "work/dtre.raw" -k $DTRE_KEY
+    ./bin/img4 -i "work/dtre.raw" -o "$savedir/DeviceTree.img4" -A -T rdtr -M $im4m
+    if [[ $IOS_VERSION != 7.* ]]; then
+        mv "tmp1/Firmware/dfu/$IBSS10" "tmp1/Firmware/dfu/$IBSS7"
+        mv "tmp1/Firmware/dfu/$IBEC10" "tmp1/Firmware/dfu/$IBEC7"
+    fi
+    ./bin/img4 -i "tmp1/Firmware/dfu/$IBSS7" -o "work/iBSS.dec" -k $IBSS_KEY
+    ./bin/img4 -i "tmp1/Firmware/dfu/$IBEC7" -o "work/iBEC.dec" -k $IBEC_KEY
+    if [[ $IOS_VERSION == 7.* || $IOS_VERSION == 8.* ]]; then
+        ./bin/ipatcher work/iBSS.dec work/iBSS.patched
+        ./bin/ipatcher work/iBEC.dec work/iBEC.patched -b "-v rd=disk0s1s1"
+    else
+        ./bin/kairos work/iBSS.dec work/iBSS.patched
+        ./bin/kairos work/iBEC.dec work/iBEC.patched -b "-v rd=disk0s1s1 amfi=0xff cs_enforcement_disable=1 keepsyms=1 debug=0x2014e wdt=-1 PE_i_can_has_debugger=1 amfi_get_out_of_my_way=0x1 amfi_unrestrict_task_for_pid=0x0"
+    fi
+    ./bin/img4 -i "work/iBSS.patched" -o "$savedir/iBSS.img4" -A -T ibss -M $im4m 
+    ./bin/img4 -i "work/iBEC.patched" -o "$savedir/iBEC.img4" -A -T ibec -M $im4m
+    ./bin/img4 -i "tmp1/$KERNELCACHE10" -o "work/kcache.raw" -k $KRNL_KEY  
+    ./bin/img4 -i "tmp1/$KERNELCACHE10" -o "work/kcache.im4p" -k $KRNL_KEY -D
+    if [[ $IOS_VERSION == 7.* ]]; then
+        ./bin/Kernel64Patcher2 "work/kcache.raw" "work/kcache.patched" -u 7 -m 7 -e 7 -f 7 -k
+    elif [[ $IOS_VERSION == 8.* ]]; then
+        ./bin/Kernel64Patcher2 "work/kcache.raw" "work/kcache.patched" -u 8 -t -p -e 8 -f 8 -a -m 8 -g -s -d
+    else
+        ./bin/Kernel64Patcher2 "work/kcache.raw" "work/kcache.patched" -u 9 -f 9 -k
+    fi     
+    ./bin/kerneldiff "work/kcache.raw" "work/kcache.patched" "work/kcache.bpatch"
+    ./bin/img4 -i "work/kcache.im4p" -o "$savedir/Kernelcache.img4" -T rkrn -P "work/kcache.bpatch" -J -M $im4m || true
+    echo "Patching complete!"
+    echo "[*] Verifying generated boot files..."
+
+    require_file "$savedir/iBSS.img4"
+    require_file "$savedir/iBEC.img4"
+    require_file "$savedir/DeviceTree.img4"
+    require_file "$savedir/Kernelcache.img4"
+
+    echo "[*] Boot files created successfully." 
+    rm -rf "work"
+    rm -rf "tmp1"
+    if ! enter_pwndfu_mode 1; then
+        echo "[!] Device is NOT in PWNDFU mode"
+        echo "[!] Aborting restore. Please re-enter DFU and try again."
+        exit 1
+    fi
+    ./bin/irecovery -f $savedir/iBSS.img4
+    ./bin/irecovery -f $savedir/iBEC.img4
+    ./bin/irecovery -f $savedir/DeviceTree.img4
+    ./bin/irecovery -c devicetree
+    ./bin/irecovery -f $savedir/Kernelcache.img4
+    ./bin/irecovery -c bootx
+    echo "Your device should now boot."
+    exit 0
+}
+
+main() {
+    bootstrap_environment
+    init_runtime_context
+    cmd_seprmvr64_boot "$@"
+}
+
+main "$@"

--- a/scripts/commands/seprmvr64_ipsw.sh
+++ b/scripts/commands/seprmvr64_ipsw.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+. "$PROJECT_ROOT/scripts/core/lib/bootstrap.sh"
+. "$PROJECT_ROOT/scripts/core/lib/usage.sh"
+. "$PROJECT_ROOT/scripts/core/lib/runtime_context.sh"
+. "$PROJECT_ROOT/scripts/core/lib/command_helpers.sh"
+. "$PROJECT_ROOT/scripts/core/lib/flows.sh"
+
+cmd_seprmvr64_ipsw() {
+    normalize_command_args "--seprmvr64-ipsw" "$@"
+    local args=("${NORMALIZED_ARGS[@]}")
+
+    if (( ${#args[@]} < 3 || ${#args[@]} > 5 )); then
+        echo "[!] Usage: --seprmvr64-ipsw [TARGET_IPSW_PATH] [BASE_IPSW_PATH] [iOS_VERSION] [--stitch-activation] [--jailbreak]"
+        exit 1
+    fi
+
+    TARGET_IPSW="${args[0]}"
+    BASE_IPSW="${args[1]}"
+    IOS_VERSION="${args[2]}"
+
+    FORCE_ACTIVATE="0"
+    if has_flag "--stitch-activation" "${args[@]:3}"; then
+        case "$IOS_VERSION" in
+            7.*|8.*|9.0*|9.1*|9.2*)
+                FORCE_ACTIVATE=1
+                ;;
+            9.3*)
+                FORCE_ACTIVATE=0
+                ;;
+            *)
+                echo "[!] Unsupported iOS version for stitch-activation: $IOS_VERSION"
+                exit 1
+                ;;
+        esac
+    fi
+    if [[ $IDENTIFIER == iPhone6,2 ]] && [[ $IOS_VERSION != 7.* ]]; then
+        echo "iPhone6,2 does not support 8.0-9.3.5 seprmvr64 restores yet in surrealra1n."
+        exit 1
+    elif [[ $IDENTIFIER == iPhone7,2 || $IDENTIFIER == iPhone7,1 ]] && [[ $IOS_VERSION != 8.4.1 ]]; then
+        echo "iPhone 6 (and 6 Plus) does not support any other than 8.4.1 seprmvr64 restores via surrealra1n"
+        exit 1
+    elif [[ $IDENTIFIER == iPad5,3 ]] && [[ $IOS_VERSION != 8.* ]]; then
+        echo "This version is not supported yet in seprmvr64-ipsw"
+        exit 1
+    elif [[ $IDENTIFIER == iPad5,1 || $IDENTIFIER == iPad5,2 || $IDENTIFIER == iPad5,4 || $IDENTIFIER == iPad4* ]]; then
+        echo "Device is not supported yet for seprmvr64-ipsw"
+        exit 1
+    fi
+    # A8(X) iOS 8.0-9.x activation error candidates
+    if [[ $IDENTIFIER == iPad5* || $IDENTIFIER == iPod7* || $IDENTIFIER == iPhone7* ]] && [[ $IOS_VERSION == 9.3* ]]; then
+        echo "[!] 9.3.x restores are blocked on A8(X) devices for the following reason."
+        echo "Recently, Apple blocked activation for A8(X) iOS 8 and 9. This means that you will not be able to activate normally, getting \"Activation Error\"."
+        if [[ $IDENTIFIER == iPhone7* ]]; then
+            echo "Since the restore will not have baseband, activation will not work, so it is strongly recommended to stitch activation records"
+        fi
+        echo "Note: stitching activation records is only for 9.2.1 and lower, and you are trying to restore to 9.3.x. Please do iOS 9.2.1 and lower."
+        exit 1
+    elif [[ $IDENTIFIER == iPad5* || $IDENTIFIER == iPod7* || $IDENTIFIER == iPhone7* ]] && [[ $IOS_VERSION != 9.3* ]]; then
+        # set FORCE_ACTIVATE=1 automatically because these are affected A8/A8X candidates, override --stitch-activation flag here
+        FORCE_ACTIVATE=1
+        echo "[!] Activation records are REQUIRED for this restore."
+        echo "[!] This is due to Apple blocking activation recently for A8(X) iOS 8 and 9."
+        echo "[!] Make sure you are on the latest iOS (must be a functional device), and fully activated via Apple's servers. Make sure to jailbreak and install OpenSSH as well."
+        read -p "Press enter to continue"
+    fi
+    if [[ $FORCE_ACTIVATE == 1 ]] && [[ $IDENTIFIER == iPad5* || $IDENTIFIER == iPod7* || $IDENTIFIER == iPhone7* ]] && [[ $IOS_VERSION == 8.2* || $IOS_VERSION == 8.1* || $IOS_VERSION == 8.0* ]]; then
+        echo "Stitching activation may work on this version, but there is a much higher chance of the device deactivating especially right after the first boot."
+        echo "It is recommended to do iOS 8.3 or later instead."
+        read -p "Press enter to continue"
+    fi
+    if has_flag "--jailbreak" "${args[@]:3}"; then
+        JAILBREAK=1
+    fi
+    if [[ $JAILBREAK != 1 ]]; then
+        echo "Jailbreak option disabled."
+        echo "Cydia will not be installed with this restore."
+        read -p "Press enter to continue"
+    fi
+    if [[ $JAILBREAK == 1 ]] && [[ $IOS_VERSION != 7.* ]]; then
+        echo "Jailbreak option not supported for iOS 8.0-9.3.5 yet, only 7.0-7.1.2."
+        JAILBREAK=0
+        read -p "Press enter to continue"
+    fi
+    if [[ $JAILBREAK == 1 ]]; then
+        mkdir -p jbresources
+        curl -L -o jbresources/pangu-untether.tar https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/resources/jailbreak/panguaxe.tar
+        curl -L -o jbresources/evasi0n7-untether.tar https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/resources/jailbreak/evasi0n7-untether.tar
+        curl -L -o jbresources/evasi0n7-untether-70.tar https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/resources/jailbreak/evasi0n7-untether-70.tar
+        curl -L -o jbresources/freeze.tar.gz https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/resources/jailbreak/freeze.tar.gz
+        gzip -dc jbresources/freeze.tar.gz > jbresources/freeze.tar
+    fi
+    if [[ "$FORCE_ACTIVATE" == "0" ]]; then
+        echo "[*] iOS version is not supported for stitch-activation. Skipping pre-activation of IPSW."
+    elif [[ "$FORCE_ACTIVATE" == "1" ]]; then
+        echo "[!] Before you can proceed, make sure your device is legitimately activated via Apple's servers on the Latest iOS (activated, not iCloud/MDM bypassed)."
+        # normalize ECID (hex -> decimal if needed)
+        if [[ "$ECID" == 0x* || "$ECID" == 0X* ]]; then
+            ECID_CLEAN="${ECID#0x}"
+            ECID_CLEAN="${ECID_CLEAN#0X}"
+            ECID_DEC=$(printf '%d' "0x$ECID_CLEAN")
+        else
+            ECID_CLEAN="$ECID"
+            ECID_DEC="$ECID"
+        fi
+        CACHE_FILE="cache/$ECID_DEC"
+
+        # check cached serial
+        if [[ -f "$CACHE_FILE" ]]; then
+            CACHED_SERIAL=$(cat "$CACHE_FILE")
+        else
+            CACHED_SERIAL=""
+        fi
+
+        # save serial to cache if empty
+        if [[ -z "$CACHED_SERIAL" ]]; then
+            if [[ -n "${SERIAL:-}" ]]; then
+                mkdir -p cache
+                echo "$SERIAL" > "$CACHE_FILE"
+                CACHED_SERIAL="$SERIAL"
+            else
+                CACHED_SERIAL="$(ls -1 activation_records 2>/dev/null | head -n 1 || true)"
+            fi
+        fi
+
+        if [[ -z "$CACHED_SERIAL" ]]; then
+            echo "[!] Could not determine SerialNumber for activation cache."
+            echo "[!] Connect device once in normal mode (activated) and rerun, or place activation files in activation_records/<SERIAL>/ manually."
+            exit 1
+        fi
+    fi
+    if [[ $FORCE_ACTIVATE == 1 ]] && [[ ! -f "activation_records/$CACHED_SERIAL/activation_record.plist" ]] && [[ ! -f "activation_records/$CACHED_SERIAL/IC-Info.sisv" ]] && [[ ! -f "activation_records/$CACHED_SERIAL/com.apple.commcenter.device_specific_nobackup.plist" ]]; then
+        echo "[!] Make sure your device is in a jailbroken state, and OpenSSH is installed."
+        echo "[!] Please DO NOT USE THIS IN THE INTENT OF BYPASSING ICLOUD, THANK YOU." 
+        mkdir -p activation_records
+        mkdir -p activation_records/$CACHED_SERIAL/
+        read -p "Press enter when it is ready. The SSH password you must input during this is "alpine" or your device's SSH password"
+        # determine what it connects by, on iOS 15.0 and later, connect as mobile, otherwise connect as root
+        if [[ $DEVICE_VERSION == 15.* ]]; then
+            CONNECT_AS="mobile"
+        else
+            CONNECT_AS="root"
+        fi
+        echo "SSH will connect as $CONNECT_AS"
+        echo "Make sure your computer and device is connected to the same Wi-Fi network."
+        read -p "Insert the IP of your device, go to Settings/Wi-Fi/Wi-Fi network/Information/IP Address: " ip_address
+        read -p "Enter the SSH Password of your device: " sshpwd
+        sudo ./bin/sshpass -p "$sshpwd" scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $CONNECT_AS@"$ip_address":/private/var/containers/Data/System/*/Library/activation_records/activation_record.plist activation_records/$CACHED_SERIAL/activation_record.plist
+        if [[ ! -f "activation_records/$CACHED_SERIAL/activation_record.plist" ]]; then
+            echo "activation_record.plist did not save correctly. Cannot continue --stitch-activation with this."
+            exit 1
+        fi
+        sudo ./bin/sshpass -p "$sshpwd" scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $CONNECT_AS@"$ip_address":/private/var/mobile/Library/FairPlay/iTunes_Control/iTunes/IC-Info.sisv activation_records/$CACHED_SERIAL/IC-Info.sisv
+        if [[ ! -f "activation_records/$CACHED_SERIAL/IC-Info.sisv" ]]; then
+            echo "IC-Info.sisv did not save correctly. Certain things may be broken."
+            read -p "You can press enter to continue, but it is usually not recommended to have an incomplete backup of activation records."
+        fi
+        if [[ $DEVICE_VERSION == 15.* ]]; then
+            # re-set permissions for com.apple.commcenter.device_specific_nobackup.plist and move to different dir, so you can download it when connected via mobile
+            sudo ./bin/sshpass -p "$sshpwd" ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $CONNECT_AS@"$ip_address" "echo "$sshpwd" | sudo -S cp /private/var/wireless/Library/Preferences/com.apple.commcenter.device_specific_nobackup.plist /private/var/containers/Data/System/"
+            sudo ./bin/sshpass -p "$sshpwd" ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $CONNECT_AS@"$ip_address" "echo "$sshpwd" | sudo -S chown mobile:mobile /private/var/containers/Data/System/com.apple.commcenter.device_specific_nobackup.plist"
+            sudo ./bin/sshpass -p "$sshpwd" scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $CONNECT_AS@"$ip_address":/private/var/containers/Data/System/com.apple.commcenter.device_specific_nobackup.plist activation_records/$CACHED_SERIAL/com.apple.commcenter.device_specific_nobackup.plist
+        else
+            sudo ./bin/sshpass -p "$sshpwd" scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $CONNECT_AS@"$ip_address":/private/var/wireless/Library/Preferences/com.apple.commcenter.device_specific_nobackup.plist activation_records/$CACHED_SERIAL/com.apple.commcenter.device_specific_nobackup.plist
+        fi
+        if [[ ! -f "activation_records/$CACHED_SERIAL/com.apple.commcenter.device_specific_nobackup.plist" ]]; then 
+            echo "com.apple.commcenter.device_specific_nobackup.plist did not save correctly."
+            read -p "You can press enter to continue, but you will not have cellular signal after activation records are stitched (that is if of course, baseband update doesn't have to be skipped)."
+        fi
+    fi        
+    echo "[!] IMPORTANT: This feature is only supported on iOS 7.0 - 9.3.5. DO NOT TRY THIS on 10.0 or later"
+    echo "[!] Warning: Before you proceed with a seprmvr64 restore, please understand the following issues you will have afterwards:"
+    echo "[!] 1. Touch ID will NOT work, at all."
+    echo "[!] 2. Passcode will NOT work, at all. Your passcode is technically NULL."
+    echo "[!] 3. Encrypted Wi-Fi networks will not work. Use an open network instead."
+    echo "[!] 4. You will have deep sleep issues, and POTENTIALLY other issues."
+    read -p "Press enter to continue. Or press CTRL + C to cancel."
+    echo "[*] Making custom IPSW..."
+    savedir="noseprestore/$IDENTIFIER/$IOS_VERSION"
+    mkdir -p "$savedir"
+    echo ""
+    unzip "$TARGET_IPSW" -d tmp1
+    unzip "$BASE_IPSW" -d tmp2
+    # Read decryption keys
+    KEY_FILE="keys/$IDENTIFIER.txt"
+    if [[ ! -f "$KEY_FILE" ]]; then
+        echo "[!] Key file $KEY_FILE not found. Aborting."
+        exit 1
+    fi
+
+    # Extract iBSS and iBEC keys
+    IBSS_KEY=$(read_key_value "$KEY_FILE" "ibss-$IOS_VERSION")
+    IBEC_KEY=$(read_key_value "$KEY_FILE" "ibec-$IOS_VERSION")
+    DTRE_KEY=$(read_key_value "$KEY_FILE" "dtre-$IOS_VERSION")
+    RDSK_KEY=$(read_key_value "$KEY_FILE" "rdsk-$IOS_VERSION")
+    KRNL_KEY=$(read_key_value "$KEY_FILE" "krnl-$IOS_VERSION")
+    ROOT_KEY=$(read_key_value "$KEY_FILE" "fstm-$IOS_VERSION")
+
+    if [[ -z "$IBSS_KEY" || -z "$IBEC_KEY" ]]; then
+        echo "[!] Missing iBSS or iBEC key for iOS $IOS_VERSION in $KEY_FILE. Aborting."
+        exit 1
+    fi
+
+    echo "[*] Found keys:"
+    echo "    iBSS Key: $IBSS_KEY"
+    echo "    iBEC Key: $IBEC_KEY"
+    if [[ $IOS_VERSION == 7.1* || $IOS_VERSION == 8.* || $IOS_VERSION == 9.* ]]; then
+        smallest_dmg=$(find_dmg tmp1 smallest)
+    else
+        smallest_dmg=$(find_dmg tmp1 largest 10370000)
+    fi
+    smallest12_dmg=$(find_dmg tmp2 smallest)
+    rootfs_dmg=$(find_dmg tmp1 largest)
+    rootfs12_dmg=$(find_dmg tmp2 largest)
+    mkdir -p work
+    rm -rf "$rootfs12_dmg"
+    ./bin/img4 -i "$smallest_dmg" -o "$smallest12_dmg" -k $RDSK_KEY -D
+    if [[ $IOS_VERSION == 8.* ]] && [[ $IDENTIFIER == iPod7* || $IDENTIFIER == iPhone7* || $IDENTIFIER == iPad5* || $FORCE_ACTIVATE == 1 ]]; then
+        # patch asr, and if A8, patch restored_external FDR step
+        ./bin/img4 -i "$smallest_dmg" -o "work/ramdisk.raw" -k $RDSK_KEY 
+        ./bin/hfsplus "work/ramdisk.raw" grow 30000000
+        ./bin/hfsplus "work/ramdisk.raw" extract usr/sbin/asr
+        ./bin/asr64_patcher asr asr_patch 
+        ./bin/ldid -e asr > ents.plist
+        ./bin/ldid -Sents.plist asr_patch
+        ./bin/hfsplus "work/ramdisk.raw" rm usr/sbin/asr
+        ./bin/hfsplus "work/ramdisk.raw" add asr_patch usr/sbin/asr
+        ./bin/hfsplus "work/ramdisk.raw" chmod 100755 usr/sbin/asr
+        if [[ $IDENTIFIER == iPod7* || $IDENTIFIER == iPhone7* || $IDENTIFIER == iPad5* ]]; then
+            ./bin/hfsplus "work/ramdisk.raw" extract usr/local/bin/restored_external
+            ./bin/restoredpatcher restored_external restored_patch -b
+            ./bin/ldid -e restored_external > ents.plist
+            ./bin/ldid -Sents.plist restored_patch
+            ./bin/hfsplus "work/ramdisk.raw" rm usr/local/bin/restored_external
+            ./bin/hfsplus "work/ramdisk.raw" add restored_patch usr/local/bin/restored_external
+            ./bin/hfsplus "work/ramdisk.raw" chmod 100755 usr/local/bin/restored_external
+            if [[ $IDENTIFIER == iPad5,3 ]]; then
+                # options plist change
+                curl -L -o options.n61.plist https://github.com/pwnerblu/surrealra1n/raw/refs/heads/development/dualboot/options.n61.plist
+                ./bin/hfsplus "work/ramdisk.raw" rm usr/local/share/restore/options.j81.plist
+                ./bin/hfsplus "work/ramdisk.raw" add options.n61.plist usr/local/share/restore/options.j81.plist
+                rm -rf options.n61.plist
+            fi
+            if [[ $IDENTIFIER == iPhone7,2 ]]; then
+                # options plist change
+                curl -L -o options.n61.plist https://github.com/pwnerblu/surrealra1n/raw/refs/heads/development/dualboot/options.n61.plist
+                ./bin/hfsplus "work/ramdisk.raw" rm usr/local/share/restore/options.n61.plist
+                ./bin/hfsplus "work/ramdisk.raw" add options.n61.plist usr/local/share/restore/options.n61.plist
+            elif [[ $IDENTIFIER == iPhone7,1 ]]; then
+                # options plist change
+                curl -L -o options.n56.plist https://github.com/pwnerblu/surrealra1n/raw/refs/heads/development/dualboot/options.n56.plist
+                ./bin/hfsplus "work/ramdisk.raw" rm usr/local/share/restore/options.n56.plist
+                ./bin/hfsplus "work/ramdisk.raw" add options.n56.plist usr/local/share/restore/options.n56.plist
+            fi
+        fi
+        ./bin/img4 -i "work/ramdisk.raw" -o "$smallest12_dmg" -A -T rdsk
+        ./bin/dmg extract "$rootfs_dmg" "tmp1/rootfs.raw" -k $ROOT_KEY
+        ./bin/hfsplus "tmp1/rootfs.raw" grow 3500000000
+        if [[ $FORCE_ACTIVATE == 1 ]]; then
+            echo "Preparing activation files..."
+            sudo cp activation_records/$CACHED_SERIAL/activation_record.plist activation.plist
+            sudo cp activation_records/$CACHED_SERIAL/IC-Info.sisv IC-Info.sisv
+            sudo cp activation_records/$CACHED_SERIAL/com.apple.commcenter.device_specific_nobackup.plist com.apple.commcenter.device_specific_nobackup.plist
+            echo "Making dirs..."
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/root/Library/Lockdown/activation_records
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/mobile/Library/mad/activation_records
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/mobile/Library/FairPlay/iTunes_Control/iTunes
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/wireless
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/wireless/Library
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/wireless/Library/Preferences
+            echo "Injecting activation files into rootfs..."
+            ./bin/hfsplus "tmp1/rootfs.raw" add activation.plist private/var/root/Library/Lockdown/activation_records/activation_record.plist
+            ./bin/hfsplus "tmp1/rootfs.raw" add activation.plist private/var/mobile/Library/mad/activation_records/activation_record.plist
+            ./bin/hfsplus "tmp1/rootfs.raw" add IC-Info.sisv private/var/mobile/Library/FairPlay/iTunes_Control/iTunes/IC-Info.sisv
+            sudo ./bin/hfsplus "tmp1/rootfs.raw" add com.apple.commcenter.device_specific_nobackup.plist private/var/wireless/Library/Preferences/com.apple.commcenter.device_specific_nobackup.plist
+            echo "Setting permissions..."
+            ./bin/hfsplus "tmp1/rootfs.raw" chmod 666 private/var/root/Library/Lockdown/activation_records/activation_record.plist
+            ./bin/hfsplus "tmp1/rootfs.raw" chmod 666 private/var/mobile/Library/mad/activation_records/activation_record.plist
+            ./bin/hfsplus "tmp1/rootfs.raw" chmod 664 private/var/mobile/Library/FairPlay/iTunes_Control/iTunes/IC-Info.sisv
+            ./bin/hfsplus "tmp1/rootfs.raw" chmod 600 private/var/wireless/Library/Preferences/com.apple.commcenter.device_specific_nobackup.plist
+            echo "Cleaning up..."
+            sudo rm -rf activation.plist
+            sudo rm -rf IC-Info.sisv
+        fi
+        ./bin/dmg build "tmp1/rootfs.raw" "$rootfs12_dmg"
+    elif [[ $IOS_VERSION == 7.* ]] && [[ $FORCE_ACTIVATE == 1 || $JAILBREAK == 1 ]]; then
+        # patch asr...
+        ./bin/img4 -i "$smallest_dmg" -o "work/ramdisk.raw" -k $RDSK_KEY 
+        ./bin/hfsplus "work/ramdisk.raw" grow 30000000
+        ./bin/hfsplus "work/ramdisk.raw" extract usr/sbin/asr
+        ./bin/asr64_patcher asr asr_patch 
+        ./bin/hfsplus "work/ramdisk.raw" rm usr/sbin/asr
+        ./bin/hfsplus "work/ramdisk.raw" add asr_patch usr/sbin/asr
+        ./bin/hfsplus "work/ramdisk.raw" chmod 100755 usr/sbin/asr
+        ./bin/img4 -i "work/ramdisk.raw" -o "$smallest12_dmg" -A -T rdsk
+        ./bin/dmg extract "$rootfs_dmg" "tmp1/rootfs.raw" -k $ROOT_KEY
+        ./bin/hfsplus "tmp1/rootfs.raw" grow 2500000000
+        if [[ $FORCE_ACTIVATE == 1 ]]; then
+            echo "Preparing activation files..."
+            sudo cp activation_records/$CACHED_SERIAL/activation_record.plist activation.plist
+            sudo cp activation_records/$CACHED_SERIAL/IC-Info.sisv IC-Info.sisv
+            sudo cp activation_records/$CACHED_SERIAL/com.apple.commcenter.device_specific_nobackup.plist com.apple.commcenter.device_specific_nobackup.plist
+            echo "Making dirs..."
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/root/Library/Lockdown/activation_records
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/mobile/Library/FairPlay/iTunes_Control/iTunes
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/wireless
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/wireless/Library
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/wireless/Library/Preferences
+            echo "Injecting activation files into rootfs..."
+            ./bin/hfsplus "tmp1/rootfs.raw" add activation.plist private/var/root/Library/Lockdown/activation_records/activation_record.plist
+            ./bin/hfsplus "tmp1/rootfs.raw" add IC-Info.sisv private/var/mobile/Library/FairPlay/iTunes_Control/iTunes/IC-Info.sisv
+            sudo ./bin/hfsplus "tmp1/rootfs.raw" add com.apple.commcenter.device_specific_nobackup.plist private/var/wireless/Library/Preferences/com.apple.commcenter.device_specific_nobackup.plist
+            echo "Setting permissions..."
+            ./bin/hfsplus "tmp1/rootfs.raw" chmod 666 private/var/root/Library/Lockdown/activation_records/activation_record.plist
+            ./bin/hfsplus "tmp1/rootfs.raw" chmod 664 private/var/mobile/Library/FairPlay/iTunes_Control/iTunes/IC-Info.sisv
+            ./bin/hfsplus "tmp1/rootfs.raw" chmod 600 private/var/wireless/Library/Preferences/com.apple.commcenter.device_specific_nobackup.plist
+            echo "Cleaning up..."
+            sudo rm -rf activation.plist
+            sudo rm -rf IC-Info.sisv
+            sudo rm -rf com.apple.commcenter.device_specific_nobackup.plist
+        fi
+        if [[ $JAILBREAK == 1 ]]; then
+            echo "Doing jailbreak stuff..."
+            if [[ $IOS_VERSION == 7.1* ]]; then
+                untether_tar="jbresources/pangu-untether.tar"
+            elif [[ $IOS_VERSION == 7.0.1* || $IOS_VERSION == 7.0.2* || $IOS_VERSION == 7.0.3* || $IOS_VERSION == 7.0.4* || $IOS_VERSION == 7.0.5* || $IOS_VERSION == 7.0.6* ]]; then
+                untether_tar="jbresources/evasi0n7-untether.tar"
+            else
+                untether_tar="jbresources/evasi0n7-untether-70.tar"
+            fi
+            ./bin/hfsplus "tmp1/rootfs.raw" untar jbresources/freeze.tar
+            ./bin/hfsplus "tmp1/rootfs.raw" untar $untether_tar
+        fi
+        ./bin/dmg build "tmp1/rootfs.raw" "$rootfs12_dmg"
+    elif [[ $IOS_VERSION == 9.* ]] && [[ $IDENTIFIER == iPod7* || $IDENTIFIER == iPhone7* || $IDENTIFIER == iPad5* || $FORCE_ACTIVATE == 1 ]]; then
+        # patch asr, and if A8, patch restored_external FDR step
+        ./bin/img4 -i "$smallest_dmg" -o "work/ramdisk.raw" -k $RDSK_KEY 
+        ./bin/hfsplus "work/ramdisk.raw" grow 40000000
+        ./bin/hfsplus "work/ramdisk.raw" extract usr/sbin/asr
+        ./bin/asr64_patcher asr asr_patch 
+        ./bin/ldid -e asr > ents.plist
+        ./bin/ldid -Sents.plist asr_patch
+        ./bin/hfsplus "work/ramdisk.raw" rm usr/sbin/asr
+        ./bin/hfsplus "work/ramdisk.raw" add asr_patch usr/sbin/asr
+        ./bin/hfsplus "work/ramdisk.raw" chmod 100755 usr/sbin/asr
+        if [[ $IDENTIFIER == iPod7* || $IDENTIFIER == iPhone7* || $IDENTIFIER == iPad5* ]]; then
+            ./bin/hfsplus "work/ramdisk.raw" extract usr/local/bin/restored_external
+            ./bin/restoredpatcher restored_external restored_patch -b
+            ./bin/ldid -e restored_external > ents.plist
+            ./bin/ldid -Sents.plist restored_patch
+            ./bin/hfsplus "work/ramdisk.raw" rm usr/local/bin/restored_external
+            ./bin/hfsplus "work/ramdisk.raw" add restored_patch usr/local/bin/restored_external
+            ./bin/hfsplus "work/ramdisk.raw" chmod 100755 usr/local/bin/restored_external
+            ./bin/img4 -i "work/ramdisk.raw" -o "$smallest12_dmg" -A -T rdsk
+        fi
+        ./bin/img4 -i "work/ramdisk.raw" -o "$smallest12_dmg" -A -T rdsk
+        ./bin/dmg extract "$rootfs_dmg" "tmp1/rootfs.raw" -k $ROOT_KEY
+        if [[ $FORCE_ACTIVATE == 1 ]]; then
+            echo "Preparing activation files..."
+            sudo cp activation_records/$CACHED_SERIAL/activation_record.plist activation.plist
+            sudo cp activation_records/$CACHED_SERIAL/IC-Info.sisv IC-Info.sisv
+            sudo cp activation_records/$CACHED_SERIAL/com.apple.commcenter.device_specific_nobackup.plist com.apple.commcenter.device_specific_nobackup.plist
+            echo "Making dirs..."
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/root/Library/Lockdown/activation_records
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/mobile/Library/mad/activation_records
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/mobile/Library/FairPlay/iTunes_Control/iTunes
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/wireless
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/wireless/Library
+            ./bin/hfsplus "tmp1/rootfs.raw" mkdir private/var/wireless/Library/Preferences
+            echo "Injecting activation files into rootfs..."
+            ./bin/hfsplus "tmp1/rootfs.raw" add activation.plist private/var/root/Library/Lockdown/activation_records/activation_record.plist
+            ./bin/hfsplus "tmp1/rootfs.raw" add activation.plist private/var/mobile/Library/mad/activation_records/activation_record.plist
+            ./bin/hfsplus "tmp1/rootfs.raw" add IC-Info.sisv private/var/mobile/Library/FairPlay/iTunes_Control/iTunes/IC-Info.sisv
+            sudo ./bin/hfsplus "tmp1/rootfs.raw" add com.apple.commcenter.device_specific_nobackup.plist private/var/wireless/Library/Preferences/com.apple.commcenter.device_specific_nobackup.plist
+            echo "Setting permissions..."
+            ./bin/hfsplus "tmp1/rootfs.raw" chmod 666 private/var/root/Library/Lockdown/activation_records/activation_record.plist
+            ./bin/hfsplus "tmp1/rootfs.raw" chmod 666 private/var/mobile/Library/mad/activation_records/activation_record.plist
+            ./bin/hfsplus "tmp1/rootfs.raw" chmod 664 private/var/mobile/Library/FairPlay/iTunes_Control/iTunes/IC-Info.sisv
+            ./bin/hfsplus "tmp1/rootfs.raw" chmod 600 private/var/wireless/Library/Preferences/com.apple.commcenter.device_specific_nobackup.plist
+            echo "Cleaning up..."
+            sudo rm -rf activation.plist
+            sudo rm -rf IC-Info.sisv
+        fi
+        ./bin/dmg build "tmp1/rootfs.raw" "$rootfs12_dmg"
+    else
+        mv "$rootfs_dmg" "$rootfs12_dmg"
+    fi
+    ./bin/img4 -i "tmp1/Firmware/all_flash/$ALLFLASH/$DEVICETREE" -o "work/dtre.raw" -k $DTRE_KEY
+    # patch content-protect string devicetree, to prevent restore freezes at keybag step
+    perl -pi -e 's/content-protect/content-protecV/g' work/dtre.raw 
+    ./bin/img4 -i "work/dtre.raw" -o "tmp2/Firmware/all_flash/$DEVICETREE" -A -T rdtr
+    if [[ $IOS_VERSION != 7.* ]]; then
+        mv "tmp1/Firmware/dfu/$IBSS10" "tmp1/Firmware/dfu/$IBSS7"
+        mv "tmp1/Firmware/dfu/$IBEC10" "tmp1/Firmware/dfu/$IBEC7"
+    fi
+    ./bin/img4 -i "tmp1/Firmware/dfu/$IBSS7" -o "work/iBSS.dec" -k "$IBSS_KEY"
+    ./bin/img4 -i "tmp1/Firmware/dfu/$IBEC7" -o "work/iBEC.dec" -k "$IBEC_KEY"
+    if [[ $IOS_VERSION == 7.* || $IOS_VERSION == 8.* ]]; then
+        ./bin/ipatcher work/iBSS.dec work/iBSS.patched
+        ./bin/ipatcher work/iBEC.dec work/iBEC.patched -b "rd=md0 debug=0x2014e -v wdt=-1 nand-enable-reformat=1 -restore amfi=0xff cs_enforcement_disable=1"
+    else
+        ./bin/kairos work/iBSS.dec work/iBSS.patched
+        ./bin/kairos work/iBEC.dec work/iBEC.patched -b "rd=md0 debug=0x2014e -v wdt=-1 nand-enable-reformat=1 -restore amfi=0xff cs_enforcement_disable=1"
+    fi
+    ./bin/img4 -i "work/iBSS.patched" -o "tmp2/Firmware/dfu/$IBSS" -A -T ibss   
+    ./bin/img4 -i "work/iBEC.patched" -o "tmp2/Firmware/dfu/$IBEC" -A -T ibec 
+    ./bin/img4 -i "tmp1/$KERNELCACHE10" -o "work/kcache.raw" -k $KRNL_KEY  
+    ./bin/img4 -i "tmp1/$KERNELCACHE10" -o "work/kcache.im4p" -k $KRNL_KEY -D
+    if [[ $IOS_VERSION == 7.* ]]; then
+        ./bin/Kernel64Patcher2 "work/kcache.raw" "work/kcache.patched" -u 7 -m 7 -e 7 -f 7 -k
+    elif [[ $IOS_VERSION == 8.* ]]; then
+        ./bin/Kernel64Patcher2 "work/kcache.raw" "work/kcache.patched" -u 8 -t -p -e 8 -f 8 -a -m 8 -g -s -d
+    else
+        ./bin/Kernel64Patcher2 "work/kcache.raw" "work/kcache.patched" -u 9 -f 9 -k -v
+    fi     
+    ./bin/kerneldiff "work/kcache.raw" "work/kcache.patched" "work/kcache.bpatch"
+    # wrap kcache into im4p
+    ./bin/img4 -i "work/kcache.im4p" -o "tmp2/$KERNELCACHE" -T rkrn -P "work/kcache.bpatch" -J || true
+    echo "Patching complete!"
+    rm -rf "work"
+    rm -rf "tmp1"
+    cd tmp2
+    zip -0 -r ../$savedir/custom.ipsw *
+    cd ..
+    rm -rf "tmp2"
+    echo "Custom IPSW is created! You can restore with: ./surrealra1n.sh --seprmvr64-restore $IOS_VERSION"
+    rm -rf "jbresources"
+    exit 0
+}
+
+main() {
+    bootstrap_environment
+    init_runtime_context
+    cmd_seprmvr64_ipsw "$@"
+}
+
+main "$@"

--- a/scripts/commands/seprmvr64_restore.sh
+++ b/scripts/commands/seprmvr64_restore.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
+. "$PROJECT_ROOT/scripts/core/lib/bootstrap.sh"
+. "$PROJECT_ROOT/scripts/core/lib/usage.sh"
+. "$PROJECT_ROOT/scripts/core/lib/runtime_context.sh"
+. "$PROJECT_ROOT/scripts/core/lib/command_helpers.sh"
+. "$PROJECT_ROOT/scripts/core/lib/flows.sh"
+
+cmd_seprmvr64_restore() {
+    normalize_command_args "--seprmvr64-restore" "$@"
+    local args=("${NORMALIZED_ARGS[@]}")
+
+    if [[ ${#args[@]} -ne 1 ]]; then
+        echo "[!] Usage: --seprmvr64-restore [iOS_VERSION]"
+        exit 1
+    fi
+    IOS_VERSION="${args[0]}"
+    echo "[!] IMPORTANT: This feature is only supported on iOS 7.0 - 9.3.5. DO NOT TRY THIS on 10.0 or later"
+    echo "[!] Warning: Before you proceed with a seprmvr64 restore, please understand the following issues you will have afterwards:"
+    echo "[!] 1. Touch ID will NOT work, at all."
+    echo "[!] 2. Passcode will NOT work, at all. Your passcode is technically NULL. Any time you're asked for a passcode, input anything."
+    echo "[!] 3. Encrypted Wi-Fi networks will not work. Use an open network instead."
+    echo "[!] 4. You will have deep sleep issues, and POTENTIALLY other issues."
+    echo "[!] 5. iOS 7.0 - 7.0.6 will likely freeze a lot after tether booting. It is recommended to do iOS 7.1 or later instead."
+    echo "[!] 6. iOS 8.x will be stuck at Slide to Upgrade afterwards. It is recommended to do 7.x or 9.x instead"
+    read -p "Press enter to continue. Or press CTRL + C to cancel."
+    echo "[*] Starting Restore to iOS $IOS_VERSION..."
+    savedir="noseprestore/$IDENTIFIER/$IOS_VERSION"
+    echo "Fetching shsh blobs for iOS $LATEST_VERSION (to extract im4m later)"
+    rm -rf "shsh"
+    mkdir -p shsh
+    sudo ./bin/tsschecker -d $IDENTIFIER -s -e $ECID -i $LATEST_VERSION --save-path shsh
+
+    # Find the .shsh2 file in the shsh directory
+    shshpath=$(require_shsh_blob "shsh")
+    if ! enter_pwndfu_mode 1; then
+        echo "[!] Aborting restore. Please re-enter DFU and try again."
+        exit 1
+    fi
+    sudo LD_LIBRARY_PATH="lib" ./bin/idevicerestore -e $savedir/custom.ipsw -y
+    echo "Restore has completed! If it's successful, you can boot with: ./surrealra1n.sh --seprmvr64-boot $IOS_VERSION"
+    if [[ $IOS_VERSION == 8.* ]]; then
+        echo "We are not done yet. You need to run this command to fix dyld: ./surrealra1n.sh --fix-ios8"
+        echo "Only after fixing dyld can you boot it normally, this is so we don't get stuck at Slide to Upgrade"
+    fi
+    exit 0
+}
+
+main() {
+    bootstrap_environment
+    init_runtime_context
+    cmd_seprmvr64_restore "$@"
+}
+
+main "$@"

--- a/scripts/core/lib/auto_update.sh
+++ b/scripts/core/lib/auto_update.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+get_latest_version() {
+    local default_latest="$CURRENT_VERSION"
+    local source_repo="${SURREALRA1N_UPDATE_REPO:-pwnerblu/surrealra1n}"
+    local url=""
+
+    if [[ "$source_repo" == "origin" ]] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        local origin_url
+        origin_url="$(git config --get remote.origin.url 2>/dev/null || true)"
+        if [[ "$origin_url" =~ github.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
+            source_repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+        fi
+    fi
+
+    url="https://raw.githubusercontent.com/${source_repo}/main/update/latest.txt"
+    UPDATE_SOURCE_REPO="$source_repo"
+    UPDATE_SOURCE_URL="https://github.com/${source_repo}.git"
+    UPDATE_SOURCE_BRANCH="${SURREALRA1N_UPDATE_BRANCH:-main}"
+    export UPDATE_SOURCE_REPO UPDATE_SOURCE_URL UPDATE_SOURCE_BRANCH
+
+    if curl -fsSL "$url" -o "$PROJECT_ROOT/update/latest.txt.tmp" 2>/dev/null; then
+        LATEST_VERSION=$(awk 'NR==1 {gsub(/\r/,""); print; exit}' "$PROJECT_ROOT/update/latest.txt.tmp")
+        RELEASE_NOTES=$(awk '/^RELEASE NOTES:/{flag=1; next} flag' "$PROJECT_ROOT/update/latest.txt.tmp")
+        mv "$PROJECT_ROOT/update/latest.txt.tmp" "$PROJECT_ROOT/update/latest.txt"
+    else
+        LATEST_VERSION="$default_latest"
+        RELEASE_NOTES=""
+        rm -f "$PROJECT_ROOT/update/latest.txt.tmp"
+    fi
+}
+
+try_git_auto_update() {
+    if [[ "${SURREALRA1N_UPDATED_ONCE:-0}" == "1" ]]; then
+        return 1
+    fi
+
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        return 1
+    fi
+
+    echo "[*] Auto-updating to $LATEST_VERSION..."
+    if git pull --rebase --autostash "$UPDATE_SOURCE_URL" "$UPDATE_SOURCE_BRANCH"; then
+        echo "[*] Update complete, restarting..."
+        SURREALRA1N_UPDATED_ONCE=1 exec "$PROJECT_ROOT/surrealra1n_new.sh" "$@"
+    fi
+
+    return 1
+}
+
+maybe_auto_update() {
+    echo "[*] Checking for updates..."
+    get_latest_version
+
+    if [[ "$LATEST_VERSION" == "$CURRENT_VERSION" ]]; then
+        echo "[*] Using current version: $CURRENT_VERSION"
+        return 0
+    fi
+
+    echo "[*] New version detected: $LATEST_VERSION (current: $CURRENT_VERSION)"
+    if [[ -n "${RELEASE_NOTES:-}" ]]; then
+        echo "RELEASE NOTES:"
+        echo "$RELEASE_NOTES"
+    fi
+
+    echo "[*] Update available. Starting auto-update..."
+    try_git_auto_update "$@" || {
+        echo "[!] Auto-update failed, continuing with current version: $CURRENT_VERSION"
+        return 0
+    }
+}

--- a/scripts/core/lib/boot_helpers.sh
+++ b/scripts/core/lib/boot_helpers.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+normal_boot() {
+    echo "[*] Proceeding to tethered boot..."
+    echo "first, your device needs to be in pwndfu mode. pwning with gaster"
+    echo "[!] Linux has low success rate for the checkm8 exploit on A6-A7. If possible, you should connect your device to a Mac or iOS device and pwn with ipwnder"
+    read -p "[!] Do you want to continue pwning with gaster? (LOW SUCCESS RATE) y/n " response
+    if [[ $response == y ]]; then
+        ./bin/gaster pwn
+    else
+        echo "Now, disconnect your device and connect it to a Mac or iOS device to pwn with ipwnder."
+        echo "For more information about pwning with an iOS device, go to <https://github.com/LukeZGD/Legacy-iOS-Kit/wiki/Pwning-Using-Another-iOS-Device>"
+        read -p "Press any key after the device is pwned with ipwnder and reconnected to this computer"
+    fi
+    ./bin/gaster reset
+    echo "[*] Verifying PWNDFU mode..."
+    irecovery_output=$(./bin/irecovery -q)
+    if echo "$irecovery_output" | grep -q "PWND"; then
+        echo "[*] Device is in PWNDFU mode"
+    else
+        echo "[!] Device is NOT in PWNDFU mode"
+        echo "[!] You cannot send the bootchain in regular DFU"
+        exit 1
+    fi
+}

--- a/scripts/core/lib/bootstrap.sh
+++ b/scripts/core/lib/bootstrap.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+bootstrap_environment() {
+    export CURRENT_VERSION="v1.3.21"
+    # Device-specific latest iOS is filled later in apply_device_profiles().
+    export LATEST_VERSION="${LATEST_VERSION:-}"
+    export DOWNGRADE_RANGE="${DOWNGRADE_RANGE:-}"
+
+    local bootstrap_lib_dir
+    bootstrap_lib_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+    PROJECT_ROOT="$(cd -- "$bootstrap_lib_dir/../../.." && pwd)"
+    SCRIPT_DIR="$PROJECT_ROOT"
+    export SCRIPT_DIR PROJECT_ROOT
+
+    # Always execute from project root so all relative paths like ./bin resolve correctly.
+    cd "$PROJECT_ROOT"
+
+    # Keep project binaries first in PATH.
+    export PATH="$PROJECT_ROOT/bin:$PATH"
+
+    mkdir -p "$PROJECT_ROOT/update" "$PROJECT_ROOT/bin"
+
+    # Migrate accidentally created command-local asset folders into root paths.
+    local accidental_bin="$PROJECT_ROOT/scripts/commands/bin"
+    local accidental_sshrd="$PROJECT_ROOT/scripts/commands/sshrd/SSHRD_Script"
+    local root_sshrd="$PROJECT_ROOT/sshrd/SSHRD_Script"
+    local f base
+
+    if [[ -d "$accidental_bin" ]]; then
+        for f in "$accidental_bin"/*; do
+            [[ -f "$f" ]] || continue
+            base="$(basename "$f")"
+            if [[ ! -e "$PROJECT_ROOT/bin/$base" ]]; then
+                mv "$f" "$PROJECT_ROOT/bin/$base"
+            else
+                rm -f "$f"
+            fi
+        done
+        rm -rf "$accidental_bin" 2>/dev/null || true
+    fi
+
+    if [[ -d "$accidental_sshrd" ]]; then
+        if [[ ! -d "$root_sshrd" ]]; then
+            mkdir -p "$PROJECT_ROOT/sshrd"
+            mv "$accidental_sshrd" "$root_sshrd"
+        fi
+        chmod -R u+w "$PROJECT_ROOT/scripts/commands/sshrd" 2>/dev/null || true
+        rm -rf "$PROJECT_ROOT/scripts/commands/sshrd" 2>/dev/null || true
+    fi
+}

--- a/scripts/core/lib/command_helpers.sh
+++ b/scripts/core/lib/command_helpers.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+normalize_command_args() {
+    local command_name="$1"
+    shift
+    NORMALIZED_ARGS=("$@")
+    if [[ "${NORMALIZED_ARGS[0]:-}" == "$command_name" ]]; then
+        NORMALIZED_ARGS=("${NORMALIZED_ARGS[@]:1}")
+    fi
+}
+
+has_flag() {
+    local target="$1"
+    shift
+    local arg
+    for arg in "$@"; do
+        if [[ "$arg" == "$target" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}

--- a/scripts/core/lib/dispatch.sh
+++ b/scripts/core/lib/dispatch.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+CORE_LIB_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd -- "$CORE_LIB_DIR/../.." && pwd)"
+COMMANDS_DIR="$SCRIPTS_DIR/commands"
+
+dispatch_command() {
+    local cmd="${1:-}"
+    shift || true
+
+    case "$cmd" in
+        --seprmvr64-ipsw) exec "$COMMANDS_DIR/seprmvr64_ipsw.sh" "$@" ;;
+        --seprmvr64-restore) exec "$COMMANDS_DIR/seprmvr64_restore.sh" "$@" ;;
+        --fix-ios8) exec "$COMMANDS_DIR/fix_ios8.sh" "$@" ;;
+        --seprmvr64-boot) exec "$COMMANDS_DIR/seprmvr64_boot.sh" "$@" ;;
+        --make-custom-ipsw) exec "$COMMANDS_DIR/make_custom_ipsw.sh" "$@" ;;
+        --make-custom-ipsw-2) exec "$COMMANDS_DIR/make_custom_ipsw_2.sh" "$@" ;;
+        --restore) exec "$COMMANDS_DIR/restore.sh" "$@" ;;
+        --downgrade) exec "$COMMANDS_DIR/downgrade.sh" "$@" ;;
+        --boot) exec "$COMMANDS_DIR/boot.sh" "$@" ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        "")
+            usage
+            exit 1
+            ;;
+        *)
+            echo "[!] Unknown option: $cmd"
+            usage
+            exit 1
+            ;;
+    esac
+}

--- a/scripts/core/lib/flows.sh
+++ b/scripts/core/lib/flows.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+require_shsh_blob() {
+    local shsh_dir="${1:-shsh}"
+    local shsh_path
+
+    shsh_path=$(find "$shsh_dir" -type f -name "*.shsh2" | head -n 1)
+    if [[ -z "$shsh_path" ]]; then
+        echo "[!] No .shsh2 blob found in $shsh_dir folder. Aborting."
+        exit 1
+    fi
+
+    printf '%s\n' "$shsh_path"
+}
+
+enter_pwndfu_mode() {
+    local allow_ignore_note="${1:-0}"
+
+    echo "first, your device needs to be in pwndfu mode. pwning with gaster"
+    echo "[!] Linux has low success rate for the checkm8 exploit on A6-A7. If possible, you should connect your device to a Mac or iOS device and pwn with ipwnder"
+    if [[ "$allow_ignore_note" == "1" ]]; then
+        echo "You can ignore this message if you are restoring an A8(X) device or newer."
+    fi
+    read -p "[!] Do you want to continue pwning with gaster? (LOW SUCCESS RATE) y/n " response
+    if [[ "$response" == "y" ]]; then
+        ./bin/gaster pwn
+    else
+        echo "Now, disconnect your device and connect it to a Mac or iOS device to pwn with ipwnder."
+        echo "For more information about pwning with an iOS device, go to <https://github.com/LukeZGD/Legacy-iOS-Kit/wiki/Pwning-Using-Another-iOS-Device>"
+        read -p "Press any key after the device is pwned with ipwnder and reconnected to this computer"
+    fi
+
+    ./bin/gaster reset
+    echo "[*] Verifying PWNDFU mode..."
+    local irecovery_output
+    irecovery_output=$(./bin/irecovery -q)
+    if echo "$irecovery_output" | grep -q "PWND"; then
+        echo "[*] Device is in PWNDFU mode"
+    else
+        echo "[!] Device is NOT in PWNDFU mode"
+        return 1
+    fi
+}
+
+read_key_value() {
+    local key_file="$1"
+    local key_name="$2"
+    grep "${key_name}:" "$key_file" | cut -d':' -f2 | xargs
+}

--- a/scripts/core/lib/ramdisk.sh
+++ b/scripts/core/lib/ramdisk.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+
+install_sshrd_script_if_missing() {
+    local clone_root="$PROJECT_ROOT/sshrd"
+    local clone_target="$clone_root/SSHRD_Script"
+
+    mkdir -p "$clone_root"
+    if [[ ! -d "$clone_target/.git" ]]; then
+        rm -rf "$clone_target"
+        echo "[*] Cloning SSHRD_Script to $clone_target ..." >&2
+        git clone https://github.com/verygenericname/SSHRD_Script "$clone_target"
+    fi
+
+    printf '%s\n' "$clone_target"
+}
+
+download_sshpass_binary() {
+    local url
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    mkdir -p "$PROJECT_ROOT/bin"
+
+    if [[ "$os" == "Darwin" ]]; then
+        url="https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/macos/sshpass"
+        if curl -fL -o "$PROJECT_ROOT/bin/sshpass" "$url"; then
+            chmod +x "$PROJECT_ROOT/bin/sshpass"
+            return
+        fi
+    elif [[ "$os" == "Linux" ]]; then
+        if [[ "$arch" == "x86_64" ]]; then
+            url="https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/linux/x86_64/sshpass"
+            if curl -fL -o "$PROJECT_ROOT/bin/sshpass" "$url"; then
+                chmod +x "$PROJECT_ROOT/bin/sshpass"
+                return
+            fi
+        fi
+
+        # Fallback attempt for non-x86 Linux hosts.
+        url="https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/linux/arm64/sshpass"
+        if curl -fL -o "$PROJECT_ROOT/bin/sshpass" "$url"; then
+            chmod +x "$PROJECT_ROOT/bin/sshpass"
+            return
+        fi
+    fi
+
+    return 1
+}
+
+download_core_ramdisk_binary() {
+    local binary="$1"
+    local os arch semaphorin_platform lik_platform url=""
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    if [[ "$os" == "Darwin" ]]; then
+        semaphorin_platform="Darwin"
+        lik_platform="macos"
+    elif [[ "$os" == "Linux" ]]; then
+        semaphorin_platform="Linux"
+        if [[ "$arch" == "x86_64" ]]; then
+            lik_platform="linux/x86_64"
+        elif [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
+            lik_platform="linux/arm64"
+        else
+            lik_platform="linux/x86_64"
+        fi
+    else
+        return 1
+    fi
+
+    case "$binary" in
+        dsc64patcher|irecovery)
+            url="https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/$semaphorin_platform/$binary"
+            ;;
+        gaster)
+            url="https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/$lik_platform/gaster"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    mkdir -p "$PROJECT_ROOT/bin"
+    if curl -fL -o "$PROJECT_ROOT/bin/$binary" "$url"; then
+        chmod +x "$PROJECT_ROOT/bin/$binary"
+        return
+    fi
+
+    return 1
+}
+
+ensure_required_ramdisk_binary() {
+    local binary="$1"
+
+    mkdir -p "$PROJECT_ROOT/bin"
+
+    if [[ -x "$PROJECT_ROOT/bin/$binary" ]]; then
+        return
+    fi
+
+    if command -v "$binary" >/dev/null 2>&1; then
+        cp "$(command -v "$binary")" "$PROJECT_ROOT/bin/$binary" || true
+        chmod +x "$PROJECT_ROOT/bin/$binary" || true
+        if [[ -x "$PROJECT_ROOT/bin/$binary" ]]; then
+            return
+        fi
+    fi
+
+    if [[ "$binary" == "sshpass" ]]; then
+        echo "[*] sshpass missing. Trying automatic install..."
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+            if command -v brew >/dev/null 2>&1; then
+                brew install hudochenkov/sshpass/sshpass || true
+            fi
+        elif [[ -r /etc/os-release ]]; then
+            # shellcheck disable=SC1091
+            . /etc/os-release
+            if [[ "${ID:-}" == "arch" || "${ID_LIKE:-}" == *"arch"* ]]; then
+                sudo pacman -S --needed sshpass || true
+            else
+                sudo apt update || true
+                sudo apt install -y sshpass || true
+            fi
+        fi
+
+        if command -v sshpass >/dev/null 2>&1; then
+            cp "$(command -v sshpass)" "$PROJECT_ROOT/bin/sshpass" || true
+            chmod +x "$PROJECT_ROOT/bin/sshpass" || true
+        fi
+
+        if [[ ! -x "$PROJECT_ROOT/bin/sshpass" ]]; then
+            echo "[*] Package-manager install did not provide sshpass. Trying direct binary download..."
+            download_sshpass_binary || true
+        fi
+
+        if [[ -x "$PROJECT_ROOT/bin/sshpass" ]]; then
+            return
+        fi
+    elif [[ "$binary" == "dsc64patcher" || "$binary" == "irecovery" || "$binary" == "gaster" ]]; then
+        echo "[*] $binary missing. Trying automatic binary download..."
+        download_core_ramdisk_binary "$binary" || true
+        if [[ -x "$PROJECT_ROOT/bin/$binary" ]]; then
+            return
+        fi
+    fi
+
+    echo "[!] Missing required binary: ./bin/$binary"
+    echo "[!] Automatic install failed. Please install it and rerun --fix-ios8."
+    exit 1
+}
+
+ensure_iproxy_available() {
+    if [[ -x "$PROJECT_ROOT/bin/iproxy" ]]; then
+        return
+    fi
+
+    if command -v iproxy >/dev/null 2>&1; then
+        cp "$(command -v iproxy)" "$PROJECT_ROOT/bin/iproxy" || true
+        chmod +x "$PROJECT_ROOT/bin/iproxy" || true
+        [[ -x "$PROJECT_ROOT/bin/iproxy" ]] && return
+    fi
+
+    echo "[*] iproxy not found. Trying to install ramdisk dependency..."
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        if command -v brew >/dev/null 2>&1; then
+            brew install usbmuxd libimobiledevice || true
+        fi
+    elif [[ -r /etc/os-release ]]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        if [[ "${ID:-}" == "arch" || "${ID_LIKE:-}" == *"arch"* ]]; then
+            sudo pacman -S --needed libusbmuxd libimobiledevice usbmuxd || true
+        else
+            sudo apt update || true
+            sudo apt install -y libusbmuxd-tools libimobiledevice-utils usbmuxd || true
+        fi
+    fi
+
+    if command -v iproxy >/dev/null 2>&1; then
+        cp "$(command -v iproxy)" "$PROJECT_ROOT/bin/iproxy" || true
+        chmod +x "$PROJECT_ROOT/bin/iproxy" || true
+    fi
+
+    if [[ ! -x "$PROJECT_ROOT/bin/iproxy" ]]; then
+        echo "[!] iproxy is still missing. Install libimobiledevice/usbmuxd and rerun."
+        exit 1
+    fi
+}
+
+ensure_ramdisk_dyld_dependencies() {
+    local required_bins=("sshpass" "dsc64patcher" "irecovery" "gaster")
+    local binary
+    for binary in "${required_bins[@]}"; do
+        ensure_required_ramdisk_binary "$binary"
+    done
+    ensure_iproxy_available
+}
+
+ensure_sshramdisk_payload() {
+    if [[ -f "$PROJECT_ROOT/sshramdisk/iBSS.img4" && \
+          -f "$PROJECT_ROOT/sshramdisk/iBEC.img4" && \
+          -f "$PROJECT_ROOT/sshramdisk/ramdisk.img4" && \
+          -f "$PROJECT_ROOT/sshramdisk/devicetree.img4" && \
+          -f "$PROJECT_ROOT/sshramdisk/kernelcache.img4" ]]; then
+        return
+    fi
+
+    local sshrd_dir
+    sshrd_dir="$(install_sshrd_script_if_missing)"
+    if [[ ! -x "$sshrd_dir/sshrd.sh" ]]; then
+        chmod +x "$sshrd_dir/sshrd.sh"
+    fi
+
+    echo "[*] Generating SSH ramdisk payload using $sshrd_dir ..."
+    (
+        cd "$sshrd_dir"
+        ./sshrd.sh 12.0
+    )
+
+    rm -rf "$PROJECT_ROOT/sshramdisk"
+    mkdir -p "$PROJECT_ROOT/sshramdisk"
+    cp -R "$sshrd_dir/sshramdisk/." "$PROJECT_ROOT/sshramdisk/"
+}
+
+run_ramdisk_boot_chain() {
+    local cpid major
+    cpid="$("$PROJECT_ROOT/bin/irecovery" -q | awk -F': ' '/^CPID:/{print $2}')"
+    major="$(awk -F. '{print $1}' "$PROJECT_ROOT/sshramdisk/version.txt" 2>/dev/null || echo 12)"
+    major="${major:-12}"
+
+    "$PROJECT_ROOT/bin/irecovery" -f "$PROJECT_ROOT/sshramdisk/iBSS.img4"
+    sleep 5
+    "$PROJECT_ROOT/bin/irecovery" -f "$PROJECT_ROOT/sshramdisk/iBEC.img4"
+    if [[ "$cpid" == "0x8010" || "$cpid" == "0x8015" || "$cpid" == "0x8011" || "$cpid" == "0x8012" ]]; then
+        "$PROJECT_ROOT/bin/irecovery" -c go || true
+    fi
+    sleep 2
+    if [[ -f "$PROJECT_ROOT/sshramdisk/logo.img4" ]]; then
+        "$PROJECT_ROOT/bin/irecovery" -f "$PROJECT_ROOT/sshramdisk/logo.img4"
+        "$PROJECT_ROOT/bin/irecovery" -c "setpicture 0x1" || true
+    fi
+    "$PROJECT_ROOT/bin/irecovery" -f "$PROJECT_ROOT/sshramdisk/ramdisk.img4"
+    "$PROJECT_ROOT/bin/irecovery" -c ramdisk
+    if [[ "$major" -ge 16 && -f "$PROJECT_ROOT/sshramdisk/sep-firmware.img4" ]]; then
+        "$PROJECT_ROOT/bin/irecovery" -f "$PROJECT_ROOT/sshramdisk/sep-firmware.img4"
+        "$PROJECT_ROOT/bin/irecovery" -c firmware
+    fi
+    "$PROJECT_ROOT/bin/irecovery" -f "$PROJECT_ROOT/sshramdisk/devicetree.img4"
+    "$PROJECT_ROOT/bin/irecovery" -c devicetree
+    if [[ "$major" -ge 12 && -f "$PROJECT_ROOT/sshramdisk/trustcache.img4" ]]; then
+        "$PROJECT_ROOT/bin/irecovery" -f "$PROJECT_ROOT/sshramdisk/trustcache.img4"
+        "$PROJECT_ROOT/bin/irecovery" -c firmware
+    fi
+    "$PROJECT_ROOT/bin/irecovery" -f "$PROJECT_ROOT/sshramdisk/kernelcache.img4"
+    "$PROJECT_ROOT/bin/irecovery" -c bootx
+}
+
+start_iproxy_tunnel_2222() {
+    pkill -f "iproxy 2222 22" >/dev/null 2>&1 || true
+    "$PROJECT_ROOT/bin/iproxy" 2222 22 >/dev/null 2>&1 &
+    sleep 1
+}
+
+wait_for_ssh_ramdisk_2222() {
+    local tries=50
+    local i
+    for ((i=1; i<=tries; i++)); do
+        if "$PROJECT_ROOT/bin/sshpass" -p "alpine" ssh root@127.0.0.1 -p2222 \
+            -o ConnectTimeout=2 -o StrictHostKeyChecking=no "echo ready" >/dev/null 2>&1; then
+            return
+        fi
+        sleep 3
+    done
+
+    echo "[!] SSH ramdisk did not become reachable on 127.0.0.1:2222."
+    exit 1
+}
+
+ensure_ssh_ramdisk_ready() {
+    if "$PROJECT_ROOT/bin/sshpass" -p "alpine" ssh root@127.0.0.1 -p2222 \
+        -o ConnectTimeout=2 -o StrictHostKeyChecking=no "echo ready" >/dev/null 2>&1; then
+        echo "[*] SSH ramdisk already running on 127.0.0.1:2222."
+        return
+    fi
+
+    ensure_ramdisk_dyld_dependencies
+    ensure_sshramdisk_payload
+
+    if ! enter_pwndfu_mode 1; then
+        echo "[!] Device is NOT in PWNDFU mode. Aborting."
+        exit 1
+    fi
+
+    run_ramdisk_boot_chain
+    start_iproxy_tunnel_2222
+    wait_for_ssh_ramdisk_2222
+}

--- a/scripts/core/lib/runtime/apply_profiles.sh
+++ b/scripts/core/lib/runtime/apply_profiles.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+
+apply_device_profiles() {
+    if [[ $IDENTIFIER == iPhone6* ]]; then
+        KERNELCACHE="kernelcache.release.iphone6"
+        LLB="LLB.iphone6.RELEASE.im4p"
+        BASEBAND10="Mav7Mav8-7.60.00.Release.bbfw"
+        IBOOT="iBoot.iphone6.RELEASE.im4p"
+        IBSS="iBSS.iphone6.RELEASE.im4p"
+        IBEC="iBEC.iphone6.RELEASE.im4p"
+    fi
+
+    if [[ $IDENTIFIER == iPhone10,1 || $IDENTIFIER == iPhone10,4 ]]; then
+        IBSS="iBSS.d20.RELEASE.im4p"
+        IBEC="iBEC.d20.RELEASE.im4p"
+        LLB="LLB.d20.RELEASE.im4p"
+        BASEBAND10="Mav7Mav8-7.60.00.Release.bbfw"
+        IBOOT="iBoot.d20.RELEASE.im4p"
+    fi
+
+    if [[ $IDENTIFIER == iPhone10,3 || $IDENTIFIER == iPhone10,6 ]]; then
+        IBSS="iBSS.d22.RELEASE.im4p"
+        IBEC="iBEC.d22.RELEASE.im4p"
+    fi
+
+    if [[ $IDENTIFIER == iPhone10,2 || $IDENTIFIER == iPhone10,5 ]]; then
+        IBSS="iBSS.d21.RELEASE.im4p"
+        IBEC="iBEC.d21.RELEASE.im4p"
+    fi
+
+    # devicetree determiner, for iPhone 8 and X
+
+    if [[ $IDENTIFIER == iPhone10,1 ]]; then
+        DEVICETREE="DeviceTree.d20ap.im4p"
+    fi
+
+    if [[ $IDENTIFIER == iPhone10,2 ]]; then
+        DEVICETREE="DeviceTree.d21ap.im4p"
+    fi
+
+    if [[ $IDENTIFIER == iPhone10,5 ]]; then
+        DEVICETREE="DeviceTree.d211ap.im4p"
+    fi
+
+    if [[ $IDENTIFIER == iPhone10,4 ]]; then
+        DEVICETREE="DeviceTree.d201ap.im4p"
+    fi
+
+    if [[ $IDENTIFIER == iPhone10,3 ]]; then
+        DEVICETREE="DeviceTree.d22ap.im4p"
+    fi
+
+    if [[ $IDENTIFIER == iPhone10,6 ]]; then
+        DEVICETREE="DeviceTree.d221ap.im4p"
+    fi
+
+    # devicetree determiner, for iPad air 2 and mini 4
+
+    if [[ $IDENTIFIER == iPad5,1 ]]; then
+        DEVICETREE="DeviceTree.j96ap.im4p"
+    fi
+
+    if [[ $IDENTIFIER == iPad5,2 ]]; then
+        DEVICETREE="DeviceTree.j97ap.im4p"
+    fi
+
+    if [[ $IDENTIFIER == iPad5,3 ]]; then
+        DEVICETREE="DeviceTree.j81ap.im4p"
+        ALLFLASH="all_flash.j81ap.production"
+        IBSS10="iBSS.j81.RELEASE.im4p"
+        IBEC10="iBEC.j81.RELEASE.im4p"
+        IBSS7="iBSS.j81ap.RELEASE.im4p"
+        IBEC7="iBEC.j81ap.RELEASE.im4p"
+        KERNELCACHE10="kernelcache.release.j81"
+    fi
+
+    if [[ $IDENTIFIER == iPad5,4 ]]; then
+        DEVICETREE="DeviceTree.j82ap.im4p"
+    fi
+
+    if [[ $IDENTIFIER == iPhone* ]]; then
+        USE_BASEBAND="--latest-baseband"
+    fi 
+
+    # iBSS and iBEC specification for iPhone 6, and DeviceTree. finish A8 support
+
+    if [[ $IDENTIFIER == iPhone7,2 ]]; then
+        IBSS="iBSS.n61.RELEASE.im4p"
+        IBEC="iBEC.n61.RELEASE.im4p"
+        DEVICETREE="DeviceTree.n61ap.im4p"
+        ALLFLASH="all_flash.n61ap.production"
+        IBSS10="iBSS.n61.RELEASE.im4p"
+        IBEC10="iBEC.n61.RELEASE.im4p"
+        # ik this device did not get ios 7
+        IBSS7="iBSS.n61ap.RELEASE.im4p"
+        IBEC7="iBEC.n61ap.RELEASE.im4p"
+        KERNELCACHE10="kernelcache.release.n61"
+    fi
+
+    # iBSS and iBEC specification for iPhone 6 Plus, and DeviceTree. finish A8 support
+
+    if [[ $IDENTIFIER == iPhone7,1 ]]; then
+        IBSS="iBSS.n56.RELEASE.im4p"
+        IBEC="iBEC.n56.RELEASE.im4p"
+        DEVICETREE="DeviceTree.n56ap.im4p"
+        ALLFLASH="all_flash.n56ap.production"
+        IBSS10="iBSS.n56.RELEASE.im4p"
+        IBEC10="iBEC.n56.RELEASE.im4p"
+        # ik this device did not get ios 7
+        IBSS7="iBSS.n56ap.RELEASE.im4p"
+        IBEC7="iBEC.n56ap.RELEASE.im4p"
+        KERNELCACHE10="kernelcache.release.n56"
+    fi
+
+    # important, for iPad air 2 and mini 4 tethered restores
+    if [[ $IDENTIFIER == iPad5,2 || $IDENTIFIER == iPad5,4 ]]; then
+        USE_BASEBAND="--latest-baseband"
+    fi 
+
+    if [[ $IDENTIFIER == iPad5,1 || $IDENTIFIER == iPad5,3 ]]; then
+        USE_BASEBAND="--no-baseband"
+    fi 
+
+    # ipad mini 2 support
+
+    if [[ $IDENTIFIER == iPad4,4 || $IDENTIFIER == iPad4,5 ]]; then
+        DOWNGRADE_RANGE="10.3 to 12.5.7"
+        NOSEP_DOWNGRADE="7.0.3 to 9.3.5 (seprmvr64 downgrades to these versions not added yet)"
+        IBSS="iBSS.ipad4b.RELEASE.im4p"
+        IBEC="iBEC.ipad4b.RELEASE.im4p"
+        if [[ $IDENTIFIER == iPad4,4 ]]; then
+            DEVICETREE="DeviceTree.j85ap.im4p"
+            USE_BASEBAND="--no-baseband"
+        else
+            DEVICETREE="DeviceTree.j86ap.im4p"
+            USE_BASEBAND="--latest-baseband"
+        fi
+        KERNELCACHE="kernelcache.release.ipad4b"
+        LLB="LLB.ipad4b.RELEASE.im4p"
+        IBOOT="iBoot.ipad4b.RELEASE.im4p"
+    fi
+
+    if [[ $IDENTIFIER == iPad4,6 ]]; then
+        DOWNGRADE_RANGE="11.3 to 12.5.7"
+        NOSEP_DOWNGRADE="7.1 to 9.3.5 (seprmvr64 downgrades to these versions not added yet)"
+        USE_BASEBAND="--latest-baseband"
+        DEVICETREE="DeviceTree.j87ap.im4p"
+        IBSS="iBSS.ipad4b.RELEASE.im4p"
+        IBEC="iBEC.ipad4b.RELEASE.im4p"
+        KERNELCACHE="kernelcache.release.ipad4b"
+    fi
+
+    if [[ $IDENTIFIER == iPad4,4 ]]; then
+        SEP="sep-firmware.j85.RELEASE.im4p"
+        IBSS10="iBSS.j85.RELEASE.im4p"
+        IBEC10="iBEC.j85.RELEASE.im4p"
+        IBSS7="iBSS.j85ap.RELEASE.im4p"
+        IBEC7="iBEC.j85ap.RELEASE.im4p"
+        IBOOT10="iBoot.j85.RELEASE.im4p"
+        LLB10="LLB.j85.RELEASE.im4p"
+        ALLFLASH="all_flash.j85ap.production"
+        KERNELCACHE10="kernelcache.release.j85"
+        sudo rm -rf "tmpmanifest"
+        mkdir -p tmpmanifest
+        cd tmpmanifest
+        curl -L -o Manifest.plist https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/resources/manifest/BuildManifest_iPad4,4_10.3.3.plist
+        cd ..
+    fi
+
+    if [[ $IDENTIFIER == iPad4,5 ]]; then
+        SEP="sep-firmware.j86.RELEASE.im4p"
+        IBSS10="iBSS.j86.RELEASE.im4p"
+        IBEC10="iBEC.j86.RELEASE.im4p"
+        IBSS7="iBSS.j86ap.RELEASE.im4p"
+        IBEC7="iBEC.j86ap.RELEASE.im4p"
+        IBOOT10="iBoot.j86.RELEASE.im4p"
+        LLB10="LLB.j86.RELEASE.im4p"
+        ALLFLASH="all_flash.j86ap.production"
+        KERNELCACHE10="kernelcache.release.j86"
+        sudo rm -rf "tmpmanifest"
+        mkdir -p tmpmanifest
+        cd tmpmanifest
+        curl -L -o Manifest.plist https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/resources/manifest/BuildManifest_iPad4,5_10.3.3.plist
+        cd ..
+    fi
+
+    if [[ $IDENTIFIER == iPad4,6 ]]; then
+        IBSS10="iBSS.j87.RELEASE.im4p"
+        IBEC10="iBEC.j87.RELEASE.im4p"
+        IBSS7="iBSS.j87ap.RELEASE.im4p"
+        IBEC7="iBEC.j87ap.RELEASE.im4p"
+        IBOOT10="iBoot.j87.RELEASE.im4p"
+        LLB10="LLB.j87.RELEASE.im4p"
+        ALLFLASH="all_flash.j87ap.production"
+        KERNELCACHE10="kernelcache.release.j87"
+    fi
+
+    # other stuff
+
+    if [[ $IDENTIFIER == iPhone7,2 ]]; then
+        LLB="LLB.n61.RELEASE.im4p"
+        IBOOT="iBoot.n61.RELEASE.im4p"
+    elif [[ $IDENTIFIER == iPhone7,1 ]]; then
+        LLB="LLB.n56.RELEASE.im4p"
+        IBOOT="iBoot.n56.RELEASE.im4p"
+    fi
+
+    if [[ $IDENTIFIER == iPhone6* ]]; then
+        LATEST_VERSION="12.5.8"
+        DOWNGRADE_RANGE="10.1 to 12.5.7"
+        NOSEP_DOWNGRADE="7.0.1 to 9.3.5"
+    elif [[ $IDENTIFIER == iPhone7* ]]; then
+        LATEST_VERSION="12.5.8"
+        DOWNGRADE_RANGE="11.3 to 12.5.7"
+        NOSEP_DOWNGRADE="8.0 to 9.3.5"
+        KERNELCACHE="kernelcache.release.iphone7"
+    elif [[ $IDENTIFIER == iPhone10,1 || $IDENTIFIER == iPhone10,4 || $IDENTIFIER == iPhone10,2 || $IDENTIFIER == iPhone10,5 ]]; then
+        LATEST_VERSION="16.7.16"
+        DOWNGRADE_RANGE="14.3 to 15.6.1"
+        KERNELCACHE="kernelcache.release.iphone10"
+    elif [[ $IDENTIFIER == iPhone10,3 || $IDENTIFIER == iPhone10,6 ]]; then
+        LATEST_VERSION="16.7.16"
+        DOWNGRADE_RANGE="14.3 to 15.6.1"
+        KERNELCACHE="kernelcache.release.iphone10b"
+    elif [[ $IDENTIFIER == iPod7,1 ]]; then
+        # ipod touch 6 support, huge thanks to bodyc1m
+        LATEST_VERSION="12.5.8"
+        DOWNGRADE_RANGE="10.3 to 12.5.7"
+        NOSEP_DOWNGRADE="8.4 to 9.3.5"
+        KERNELCACHE="kernelcache.release.n102"
+        KERNELCACHE10="kernelcache.release.n102"
+        LLB="LLB.n102.RELEASE.im4p"
+        IBOOT="iBoot.n102.RELEASE.im4p"
+        IBSS="iBSS.n102.RELEASE.im4p"
+        IBEC="iBEC.n102.RELEASE.im4p"
+        DEVICETREE="DeviceTree.n102ap.im4p"
+        # parser for iOS 8.4-9.3.5 no SEP tethered (ios 7 doesnt exist on that device ik)
+        IBSS10="iBSS.n102.RELEASE.im4p"
+        IBEC10="iBEC.n102.RELEASE.im4p"
+        IBSS7="iBSS.n102ap.RELEASE.im4p"
+        IBEC7="iBEC.n102ap.RELEASE.im4p"
+        ALLFLASH="all_flash.n102ap.production"
+        USE_BASEBAND="--no-baseband"
+    elif [[ $IDENTIFIER == iPad5,1 || $IDENTIFIER == iPad5,2 ]]; then
+        LATEST_VERSION="15.8.8"
+        DOWNGRADE_RANGE="11.3 to 15.8.5"
+        NOSEP_DOWNGRADE="9.0 to 9.3.5"
+        IBSS="iBSS.ipad5.RELEASE.im4p"
+        IBEC="iBEC.ipad5.RELEASE.im4p"
+        KERNELCACHE="kernelcache.release.ipad5"
+        LLB="LLB.ipad5.RELEASE.im4p"
+        IBOOT="iBoot.ipad5.RELEASE.im4p"
+    elif [[ $IDENTIFIER == iPad5,3 || $IDENTIFIER == iPad5,4 ]]; then
+        LATEST_VERSION="15.8.8"
+        DOWNGRADE_RANGE="11.3 to 15.8.5"
+        NOSEP_DOWNGRADE="8.1 to 9.3.5"
+        IBSS="iBSS.ipad5b.RELEASE.im4p"
+        IBEC="iBEC.ipad5b.RELEASE.im4p"
+        KERNELCACHE="kernelcache.release.ipad5b"
+    elif [[ $IDENTIFIER == iPad4,4 || $IDENTIFIER == iPad4,5 || $IDENTIFIER == iPad4,6 ]]; then
+        LATEST_VERSION="12.5.8"
+    else
+        echo "Unsupported device, press enter to continue if you are going to do an untethered downgrade with saved SHSH (use --downgrade [IPSW FILE] [SHSH BLOB])"
+        read -p ""
+    fi
+
+    if [[ $IDENTIFIER == iPhone6,1 ]]; then
+        SEP="sep-firmware.n51.RELEASE.im4p"
+        IBSS10="iBSS.n51.RELEASE.im4p"
+        IBEC10="iBEC.n51.RELEASE.im4p"
+        IBSS7="iBSS.n51ap.RELEASE.im4p"
+        IBEC7="iBEC.n51ap.RELEASE.im4p"
+        IBOOT10="iBoot.n51.RELEASE.im4p"
+        LLB10="LLB.n51.RELEASE.im4p"
+        ALLFLASH="all_flash.n51ap.production"
+        KERNELCACHE10="kernelcache.release.n51"
+        DEVICETREE="DeviceTree.n51ap.im4p"
+        sudo rm -rf "tmpmanifest"
+        mkdir -p tmpmanifest
+        cd tmpmanifest
+        curl -L -o Manifest.plist https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/resources/manifest/BuildManifest_iPhone6,1_10.3.3.plist
+        cd ..
+    fi
+
+    if [[ $IDENTIFIER == iPhone6,2 ]]; then
+        SEP="sep-firmware.n53.RELEASE.im4p"
+        IBOOT10="iBoot.n53.RELEASE.im4p"
+        LLB10="LLB.n53.RELEASE.im4p"
+        ALLFLASH="all_flash.n53ap.production"
+        KERNELCACHE10="kernelcache.release.n53"
+        IBSS10="iBSS.n53.RELEASE.im4p"
+        IBEC10="iBEC.n53.RELEASE.im4p"
+        IBSS7="iBSS.n53ap.RELEASE.im4p"
+        IBEC7="iBEC.n53ap.RELEASE.im4p"
+        DEVICETREE="DeviceTree.n53ap.im4p"
+        sudo rm -rf "tmpmanifest"
+        mkdir -p tmpmanifest
+        cd tmpmanifest
+        curl -L -o Manifest.plist https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/resources/manifest/BuildManifest_iPhone6,2_10.3.3.plist
+        cd ..
+    fi
+
+    mnifst="tmpmanifest/Manifest.plist"
+}

--- a/scripts/core/lib/runtime/detect_device.sh
+++ b/scripts/core/lib/runtime/detect_device.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+detect_connected_device() {
+    # Keep these defined for set -u even in DFU/recovery paths.
+    IDENTIFIER="${IDENTIFIER:-}"
+    ECID="${ECID:-}"
+    SERIAL="${SERIAL:-}"
+    DEVICE_VERSION="${DEVICE_VERSION:-}"
+
+    # Run ideviceinfo and capture both output and return code
+    IDEVICE_INFO=$(ideviceinfo 2>&1) || true
+    IDEVICE_STATUS=$?
+
+    if [[ $IDEVICE_STATUS -eq 0 && "$IDEVICE_INFO" != *"No device found!"* ]]; then
+        echo "[*] Device is in normal mode."
+
+        # Extract ProductType and UniqueChipID
+        IDENTIFIER=$(echo "$IDEVICE_INFO" | grep "^ProductType:" | cut -d ':' -f2 | xargs)
+        ECID=$(echo "$IDEVICE_INFO" | grep "^UniqueChipID:" | cut -d ':' -f2 | xargs)
+        SERIAL=$(echo "$IDEVICE_INFO" | grep "^SerialNumber:" | cut -d ':' -f2 | xargs)
+        DEVICE_VERSION=$(echo "$IDEVICE_INFO" | grep "^ProductVersion:" | cut -d ':' -f2 | xargs)
+
+        echo "[+] Device Identifier: $IDENTIFIER"
+        echo "[+] ECID: $ECID"
+
+    else
+        echo "[*] Device is not in normal mode. Trying recovery/DFU mode..."
+
+        # Try irecovery
+        IRECOVERY_INFO=$(./bin/irecovery -q 2>/dev/null) || true
+
+        if [[ -n "$IRECOVERY_INFO" ]]; then
+            echo "[*] Device is in Recovery or DFU mode."
+
+            # Extract PRODUCT and ECID
+            IDENTIFIER=$(echo "$IRECOVERY_INFO" | grep "^PRODUCT:" | cut -d ':' -f2 | xargs)
+            ECID=$(echo "$IRECOVERY_INFO" | grep "^ECID:" | cut -d ':' -f2 | xargs)
+
+            echo "[+] Device Identifier: $IDENTIFIER"
+            echo "[+] ECID: $ECID"
+
+        else
+            echo "[!] No device detected in normal or recovery mode."
+            exit 1
+        fi
+    fi
+
+}

--- a/scripts/core/lib/runtime/prepare_environment.sh
+++ b/scripts/core/lib/runtime/prepare_environment.sh
@@ -1,0 +1,479 @@
+#!/usr/bin/env bash
+
+prepare_runtime_environment() {
+    echo "surrealra1n - $CURRENT_VERSION"
+    echo "Tether Downgrader for some checkm8 64bit devices, iOS 7.0 - 16.6.1"
+    echo ""
+    echo "Uses latest SHSH blobs (for tethered downgrades)"
+    echo "iSuns9 fork of asr64_patcher is used for patching ASR"
+    echo "Huge thanks to bodyc1m (discord username: cashcart1capone) for iPod touch 6 support, including the Arch Linux port they did."
+    echo "Huge thanks to Mineek for openra1n and seprmvr64."
+
+    # Request sudo password upfront
+    echo "Enter your user password when prompted to"
+    sudo -v || exit 1
+
+    macmodel=$(sysctl -n hw.model) || true
+
+    # Outdated macOS ver check
+    macos_ver=$(sw_vers -productVersion) || true
+
+    dist=0
+
+    JAILBREAK=0
+
+    DISTRO="Unsupported"
+    ARCH="$(uname -m)"
+
+    # macOS detection
+    if [[ "$(uname)" == "Darwin" ]]; then
+        DISTRO="macOS"
+
+        if [[ "$ARCH" == "arm64" ]]; then
+            echo "You are running surrealra1n on an Apple Silicon Mac."
+            echo "Please read the following guide before continuing: https://github.com/pwnerblu/surrealra1n/wiki/Getting-started-with-surrealra1n-(macOS)"
+            read -n 1 -s -r -p "Press any key to continue"
+            dist=3
+            echo
+        elif [[ "$ARCH" == "x86_64" ]]; then
+            echo "You are running surrealra1n on Intel macOS."
+            echo "Please read the following guide before continuing: https://github.com/pwnerblu/surrealra1n/wiki/Getting-started-with-surrealra1n-(macOS)"
+            read -n 1 -s -r -p "Press any key to continue"
+            dist=4
+            echo
+        fi
+
+    # Linux detection
+    elif [[ -r /etc/os-release ]]; then
+        . /etc/os-release
+
+        if [[ "$ID" == "arch" || "$ID_LIKE" == *arch* ]]; then
+            DISTRO="Arch"
+            dist=2
+        elif [[ "$ID" == "debian" || "$ID_LIKE" == *debian* ]]; then
+            DISTRO="Debian"
+            dist=1
+            read -n 1 -s -r -p "Press any key to continue"
+        fi
+    fi
+
+    if [[ $dist == 3 || $dist == 4 ]] && [[ "$(printf) '%s\n' "10.11" "$macos_ver" | sort -V | head -n1)" != "$macos_ver" ]]; then
+        echo "Your macOS version $macos_ver is supported."
+    else
+        echo "surrealra1n only supports macOS versions after 10.11. Learn more at https://github.com/pwnerblu/surrealra1n"
+        echo "You can continue however features WILL be broken."
+        echo "Your macOS X version:$macos_ver"
+        read -n 1 -s -r -p "Press any key to continue"
+        echo
+    fi
+
+    if [[ "$macmodel" == "Mac17,5" ]]; then
+        echo "There is a problem with the MacBook Neo in which openra1n fails to compile."
+        echo "You cannot boot jailbroken with palera1n on tethered downgrades without openra1n, however for everything else it should be fine."
+        echo "It will be fixed soon enough."
+        read -n 1 -s -r -p "Press any key to continue"
+        echo
+    fi
+
+
+    # Unsupported check
+    if [[ "$DISTRO" == "Unsupported" ]]; then
+        echo "Unsupported Linux distribution."
+        echo "This script only supports Debian-based, Arch-based and macOS systems."
+        exit 1
+    fi
+
+    echo "Detected distro family: $DISTRO"
+
+    if [[ $dist == 3 || $dist == 4 ]]; then
+        zenity="./bin/zenity"
+    else
+        zenity="zenity"
+    fi
+
+
+    # Dependency check
+    echo "Checking for required dependencies..."
+
+    if [[ $dist == 1 ]]; then
+        DEPENDENCIES=(libusb-1.0-0-dev libusbmuxd-tools libimobiledevice-utils usbmuxd zenity git curl make gcc)
+        MISSING_PACKAGES=()
+
+        for pkg in "${DEPENDENCIES[@]}"; do
+            if ! dpkg -s "$pkg" &>/dev/null; then
+                MISSING_PACKAGES+=("$pkg")
+            fi
+        done
+
+        if [ ${#MISSING_PACKAGES[@]} -ne 0 ]; then
+            echo "Missing packages detected: ${MISSING_PACKAGES[*]}"
+            echo "Installing missing dependencies..."
+            sudo apt update
+            sudo apt install -y "${MISSING_PACKAGES[@]}"
+        else
+            echo "All dependencies are installed." 
+        fi
+    elif [[ $dist == 2 ]]; then
+        DEPENDENCIES=(libusb libusbmuxd libimobiledevice usbmuxd zenity git curl make gcc base-devel)
+        MISSING_PACKAGES=()
+
+
+        for pkg in "${DEPENDENCIES[@]}"; do
+            if ! pacman -Qi "$pkg" &>/dev/null; then
+                MISSING_PACKAGES+=("$pkg")
+            fi
+        done
+
+        if [ ${#MISSING_PACKAGES[@]} -ne 0 ]; then
+            echo "Missing packages detected: ${MISSING_PACKAGES[*]}"
+            echo "Installing missing dependencies..."
+            sudo pacman -Syu --needed "${MISSING_PACKAGES[@]}"
+        else
+            echo "All dependencies are already installed."
+        fi
+    elif [[ "$DISTRO" == "unknown" ]]; then
+        echo "Unsupported Linux distribution."
+        echo "This script only supports Debian-based and Arch-based systems."
+        exit 1
+    fi
+
+    #
+    stat_size() {
+        if stat -c %s "$1" >/dev/null 2>&1; then
+            stat -c %s "$1"     # Linux (GNU)
+        else
+            stat -f %z "$1"     # macOS / BSD
+        fi
+    }
+
+    find_dmg() {
+        dir="$1"          # directory to search
+        mode="$2"         # smallest | largest
+        max_size="${3:-}"     # optional (bytes)
+
+        find "$dir" -type f -name '*.dmg' ! -name '._*' -print |
+        while IFS= read -r f; do
+            size=$(stat_size "$f") || continue
+            if [[ -n "$max_size" && "$size" -ge "$max_size" ]]; then
+                continue
+            fi
+            printf '%s %s\n' "$size" "$f"
+        done |
+        if [[ "$mode" == "smallest" ]]; then
+            sort -n
+        else
+            sort -nr
+        fi |
+        head -n 1 |
+        cut -d' ' -f2-
+    }
+
+    # boot file error handling improvements
+
+    require_file() {
+        if [[ ! -f "$1" ]]; then
+            echo "[!] Required file missing: $1"
+            exit 1
+        fi
+    }
+
+    require_dir() {
+        if [[ ! -d "$1" ]]; then
+            echo "[!] Required directory missing: $1"
+            exit 1
+        fi
+    }
+
+    #
+
+    # Updates are handled centrally by scripts/core/lib/auto_update.sh.
+
+    echo "Checking for existing binaries..."
+
+    #!/bin/bash
+
+    # Check if all required binaries exist
+    if [[ -f "./bin/img4" && \
+          -f "./bin/img4tool" && \
+          -f "./bin/irecovery" && \
+          -f "./bin/kairos" && \
+          -f "./bin/kerneldiff" && \
+          -f "./bin/KPlooshFinder" && \
+          -f "./bin/gaster" && \
+          -f "./bin/Kernel64Patcher" && \
+          -f "./bin/Kernel64Patcher2" && \
+          -f "./bin/dmg" && \
+          -f "./bin/pzb" && \
+          -f "./bin/zenity" && \
+          -f "./bin/iBoot64Patcher" && \
+          -f "./bin/asr64_patcher" && \
+          -f "./bin/ipx_restored_patcher" && \
+          -f "./bin/restored_external64_patcher" && \
+          -f "./bin/restoredpatcher" && \
+          -f "./bin/hfsplus" && \
+          -f "./bin/tsschecker" && \
+          -f "./bin/ipatcher" && \
+          -f "./bin/dsc64patcher" && \
+          -f "./bin/idevicerestore" && \
+          -f "./bin/ldid" && \
+          -f "./activate.sh" && \
+          -f "./backup.sh" && \
+          -f "./futurerestore/futurerestore" ]]; then
+        echo "Found necessary binaries."
+    elif [[ $dist == 3 ]]; then
+        echo "Binaries do not exist"
+        echo "Downloading binaries..."
+
+        mkdir -p bin futurerestore
+
+        curl -L -o bin/img4 https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/img4
+        curl -L -o bin/img4tool https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/img4tool
+        curl -L -o bin/pzb https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/pzb
+        curl -L -o bin/KPlooshFinder https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/KPlooshFinder
+        curl -L -o bin/dsc64patcher https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/dsc64patcher
+        curl -L -o bin/kerneldiff https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/kerneldiff
+        curl -L -o bin/irecovery https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/irecovery
+        curl -L -o bin/iBoot64Patcher https://github.com/edwin170/downr1n/raw/refs/heads/main/binaries/Darwin/iBoot64Patcher
+        curl -L -o bin/Kernel64Patcher2 https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/Kernel64Patcher
+        curl -L -o bin/hfsplus https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/macos/hfsplus
+        curl -L -o bin/zenity https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/macos/zenity
+        # sshpass
+        curl -L -o bin/sshpass https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/macos/sshpass
+        curl -L -o bin/dmg https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/dmg
+        curl -L -o bin/ipatcher https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/iPatcher
+        # install additional restored_external patcher (iPhone X only)
+        curl -L -o bin/ipx_restored_patcher https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/macos/arm64/ipx_restored_patcher
+        # restored patcher for seprmvr64 A8+ restores, my fork of mineek's restored patcher but repurposed
+        curl -L -o main.c https://gist.githubusercontent.com/pwnerblu/d2adc5adee74a679704577ddd64508bf/raw/991a74e2bbbdebdb1dd2d49d82f0829e7553f02f/main.c
+        gcc main.c -o bin/restoredpatcher
+        rm -rf main.c
+        # install asr patcher for tethered restores
+        git clone https://github.com/iSuns9/asr64_patcher --recursive
+        cd asr64_patcher
+        make
+        mv asr64_patcher ../bin/asr64_patcher
+        cd ..
+        rm -rf "asr64_patcher"
+        # install restored_external patcher for tethered restores to iOS 14+
+        git clone https://github.com/iSuns9/restored_external64patcher --recursive
+        cd restored_external64patcher
+        make
+        mv restored_external64_patcher ../bin/restored_external64_patcher
+        cd ..
+        rm -rf "restored_external64patcher"
+        # install libimg4 patcher for tethered restores to iOS 14/15, primarily convert to localboot
+        git clone https://github.com/iSuns9/libimg4_patcher --recursive
+        cd libimg4_patcher
+        make
+        mv libimg4_patcher ../bin/libimg4_patcher
+        cd ..
+        rm -rf "libimg4_patcher"
+        # the favor goes to openra1n by Mineek (pongoOS on unsigned bootchains), uses Nick Chan fork of openra1n
+        git clone https://github.com/asdfugil/openra1n -b ipad6
+        cd openra1n
+        curl -L -o Makefile https://github.com/mineek/openra1n/raw/refs/heads/sigcheck/Makefile
+        make || true
+        mv openra1n ../bin/openra1n || true
+        cd ..
+        rm -rf "openra1n"
+        # palera1n macOS bin
+        curl -L -o bin/palera1n https://github.com/palera1n/palera1n/releases/download/v2.2.1/palera1n-macos-universal
+        # install Kernel64Patcher for tether booting iOS 13+
+        curl -L -o bin/Kernel64Patcher https://github.com/edwin170/downr1n/raw/refs/heads/main/binaries/Darwin/Kernel64Patcher
+        curl -L -o bin/gaster https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/macos/gaster
+        curl -L -o bin/tsschecker https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/macos/tsschecker
+        curl -L -o bin/ldid https://github.com/ProcursusTeam/ldid/releases/download/v2.1.5-procursus7/ldid_macosx_arm64
+        curl -L -o bin/kairos https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/kairos
+        # download activate.sh and backup.sh from hiylx's eclipsera1n, for backing up and restoring iOS 16+ activation files on 14.0-15.7(.2)
+        curl -L -o activate.sh https://github.com/hiylx/eclipsera1n/raw/refs/heads/main/activate.sh
+        curl -L -o backup.sh https://github.com/hiylx/eclipsera1n/raw/refs/heads/main/backup.sh
+        curl -L -o futurerestore/futurerestore.zip https://github.com/LukeeGD/futurerestore/releases/download/latest/futurerestore-macOS-RELEASE-main.zip
+        # fetch idevicerestore for 7.0-9.3.5 restores 
+        curl -L -o bin/idevicerestore https://github.com/NyanSatan/SundanceInH2A/raw/refs/heads/master/executables/Darwin/idevicerestore
+        # libs
+        chmod +x bin/*
+        chmod +x *.sh
+
+        cd futurerestore || exit
+        unzip -o futurerestore.zip
+        tar -xf futurerestore-macOS-v2.0.0-Build_329-RELEASE.tar.xz
+        cp futurerestore-macOS-v2.0.0-Build_329-RELEASE/* . || true
+        chmod +x futurerestore
+        rm -rf *.tar.xz
+        rm -rf *.sh
+        rm -rf *.zip
+        rm -rf "futurerestore-macOS-v2.0.0-Build_329-RELEASE" 
+        cd ..
+        xattr -c bin/*
+        xattr -c futurerestore/futurerestore
+    elif [[ $dist == 4 ]]; then
+        echo "Binaries do not exist"
+        echo "Downloading binaries..."
+
+        mkdir -p bin futurerestore
+
+        curl -L -o bin/img4 https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/img4
+        curl -L -o bin/img4tool https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/img4tool
+        curl -L -o bin/pzb https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/pzb
+        curl -L -o bin/KPlooshFinder https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/KPlooshFinder
+        curl -L -o bin/dsc64patcher https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/dsc64patcher
+        curl -L -o bin/kerneldiff https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/kerneldiff
+        curl -L -o bin/irecovery https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/irecovery
+        curl -L -o bin/iBoot64Patcher https://github.com/edwin170/downr1n/raw/refs/heads/main/binaries/Darwin/iBoot64Patcher
+        curl -L -o bin/Kernel64Patcher2 https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/Kernel64Patcher
+        curl -L -o bin/hfsplus https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/macos/hfsplus
+        curl -L -o bin/zenity https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/macos/zenity
+        # sshpass
+        curl -L -o bin/sshpass https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/macos/sshpass
+        curl -L -o bin/dmg https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/dmg
+        curl -L -o bin/ipatcher https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/iPatcher
+        # install additional restored_external patcher (iPhone X only)
+        curl -L -o bin/ipx_restored_patcher https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/macos/ipx_restored_patcher
+        # palera1n macOS bin
+        curl -L -o bin/palera1n https://github.com/palera1n/palera1n/releases/download/v2.2.1/palera1n-macos-universal
+        # the favor goes to openra1n by Mineek (pongoOS on unsigned bootchains), uses Nick Chan fork of openra1n
+        git clone https://github.com/asdfugil/openra1n -b ipad6
+        cd openra1n
+        curl -L -o Makefile https://github.com/mineek/openra1n/raw/refs/heads/sigcheck/Makefile
+        make OBJCOPY=$(brew --prefix)/opt/binutils/bin/gobjcopy || true
+        mv openra1n ../bin/openra1n || true
+        cd ..
+        rm -rf "openra1n" 
+        # restored patcher for seprmvr64 A8+ restores, my fork of mineek's restored patcher but repurposed
+        curl -L -o main.c https://gist.githubusercontent.com/pwnerblu/d2adc5adee74a679704577ddd64508bf/raw/991a74e2bbbdebdb1dd2d49d82f0829e7553f02f/main.c
+        gcc main.c -o bin/restoredpatcher
+        rm -rf main.c
+        # install asr patcher for tethered restores
+        git clone https://github.com/iSuns9/asr64_patcher --recursive
+        cd asr64_patcher
+        make
+        mv asr64_patcher ../bin/asr64_patcher
+        cd ..
+        rm -rf "asr64_patcher"
+        # install restored_external patcher for tethered restores to iOS 14+
+        git clone https://github.com/iSuns9/restored_external64patcher --recursive
+        cd restored_external64patcher
+        make
+        mv restored_external64_patcher ../bin/restored_external64_patcher
+        cd ..
+        rm -rf "restored_external64patcher"
+        # install libimg4 patcher for tethered restores to iOS 14/15, primarily convert to localboot
+        git clone https://github.com/iSuns9/libimg4_patcher --recursive
+        cd libimg4_patcher
+        make
+        mv libimg4_patcher ../bin/libimg4_patcher
+        cd ..
+        rm -rf "libimg4_patcher"
+        # install Kernel64Patcher for tether booting iOS 13+
+        curl -L -o bin/Kernel64Patcher https://github.com/edwin170/downr1n/raw/refs/heads/main/binaries/Darwin/Kernel64Patcher
+        curl -L -o bin/gaster https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/macos/gaster
+        curl -L -o bin/tsschecker https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/macos/tsschecker
+        curl -L -o bin/ldid https://github.com/ProcursusTeam/ldid/releases/download/v2.1.5-procursus7/ldid_macosx_x86_64
+        curl -L -o bin/kairos https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Darwin/kairos
+        # download activate.sh and backup.sh from hiylx's eclipsera1n, for backing up and restoring iOS 16+ activation files on 14.0-15.7(.2)
+        curl -L -o activate.sh https://github.com/hiylx/eclipsera1n/raw/refs/heads/main/activate.sh
+        curl -L -o backup.sh https://github.com/hiylx/eclipsera1n/raw/refs/heads/main/backup.sh
+        curl -L -o futurerestore/futurerestore.zip https://github.com/LukeeGD/futurerestore/releases/download/latest/futurerestore-macOS-RELEASE-main.zip
+        # fetch idevicerestore for 7.0-9.3.5 restores 
+        curl -L -o bin/idevicerestore https://github.com/NyanSatan/SundanceInH2A/raw/refs/heads/master/executables/Darwin/idevicerestore
+        # libs
+        chmod +x bin/*
+        chmod +x *.sh
+
+        cd futurerestore || exit
+        unzip -o futurerestore.zip
+        tar -xf futurerestore-macOS-v2.0.0-Build_329-RELEASE.tar.xz
+        cp futurerestore-macOS-v2.0.0-Build_329-RELEASE/* . || true
+        chmod +x futurerestore
+        rm -rf *.tar.xz
+        rm -rf *.sh
+        rm -rf *.zip
+        rm -rf "futurerestore-macOS-v2.0.0-Build_329-RELEASE" 
+        cd ..
+        xattr -c bin/*
+        xattr -c futurerestore/futurerestore
+    else
+        echo "Binaries do not exist"
+        echo "Downloading binaries..."
+
+        mkdir -p bin futurerestore
+
+        curl -L -o bin/img4 https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Linux/img4
+        curl -L -o bin/img4tool https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Linux/img4tool
+        curl -L -o bin/KPlooshFinder https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Linux/KPlooshFinder
+        curl -L -o bin/pzb https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Linux/pzb
+        curl -L -o bin/dsc64patcher https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Linux/dsc64patcher
+        curl -L -o bin/kerneldiff https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Linux/kerneldiff
+        curl -L -o bin/irecovery https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Linux/irecovery
+        curl -L -o bin/iBoot64Patcher https://github.com/edwin170/downr1n/raw/refs/heads/main/binaries/Linux/iBoot64Patcher
+        curl -L -o bin/Kernel64Patcher2 https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Linux/Kernel64Patcher
+        curl -L -o bin/hfsplus https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Linux/hfsplus
+        # sshpass
+        curl -L -o bin/sshpass https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/linux/x86_64/sshpass
+        curl -L -o bin/zenity https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/linux/x86_64/zenity
+        curl -L -o bin/dmg https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Linux/dmg
+        curl -L -o bin/ipatcher https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Linux/ipatcher
+        # install additional restored_external patcher (iPhone X only)
+        curl -L -o bin/ipx_restored_patcher https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/linux/x86_64/ipx_restored_patcher
+        # restored patcher for seprmvr64 A8+ restores, my fork of mineek's restored patcher but repurposed
+        curl -L -o main.c https://gist.githubusercontent.com/pwnerblu/d2adc5adee74a679704577ddd64508bf/raw/991a74e2bbbdebdb1dd2d49d82f0829e7553f02f/main.c
+        gcc main.c -o bin/restoredpatcher
+        rm -rf main.c
+        # install asr patcher for tethered restores
+        git clone https://github.com/iSuns9/asr64_patcher --recursive
+        cd asr64_patcher
+        make
+        mv asr64_patcher ../bin/asr64_patcher
+        cd ..
+        rm -rf "asr64_patcher"
+        # install restored_external patcher for tethered restores to iOS 14+
+        git clone https://github.com/iSuns9/restored_external64patcher --recursive
+        cd restored_external64patcher
+        make
+        mv restored_external64_patcher ../bin/restored_external64_patcher
+        cd ..
+        rm -rf "restored_external64patcher"
+        # install libimg4 patcher for tethered restores to iOS 14/15, primarily convert to localboot
+        git clone https://github.com/iSuns9/libimg4_patcher --recursive
+        cd libimg4_patcher
+        make
+        mv libimg4_patcher ../bin/libimg4_patcher
+        cd ..
+        rm -rf "libimg4_patcher"
+        # install Kernel64Patcher for tether booting iOS 13+
+        curl -L -o bin/Kernel64Patcher https://github.com/edwin170/downr1n/raw/refs/heads/main/binaries/Linux/Kernel64Patcher
+        curl -L -o bin/gaster https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/linux/x86_64/gaster
+        curl -L -o bin/tsschecker https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/linux/x86_64/tsschecker
+        curl -L -o bin/ldid https://github.com/ProcursusTeam/ldid/releases/download/v2.1.5-procursus7/ldid_linux_x86_64
+        curl -L -o bin/kairos https://github.com/LukeZGD/Semaphorin/raw/refs/heads/main/Linux/kairos
+        # download activate.sh and backup.sh from hiylx's eclipsera1n, for backing up and restoring iOS 16+ activation files on 14.0-15.7(.2)
+        curl -L -o activate.sh https://github.com/hiylx/eclipsera1n/raw/refs/heads/main/activate.sh
+        curl -L -o backup.sh https://github.com/hiylx/eclipsera1n/raw/refs/heads/main/backup.sh
+        curl -L -o futurerestore/futurerestore.zip https://github.com/LukeeGD/futurerestore/releases/download/latest/futurerestore-Linux-x86_64-RELEASE-main.zip
+        # fetch idevicerestore for 7.0-9.3.5 restores 
+        curl -L -o bin/idevicerestore https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/linux/x86_64/idevicerestore2
+        # libs
+        rm -rf "lib"
+        mkdir lib
+        curl -L -o lib/libcrypto.so.35 https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/linux/x86_64/lib/libcrypto.so.35
+        curl -L -o lib/libssl.so.35 https://github.com/LukeZGD/Legacy-iOS-Kit/raw/refs/heads/main/bin/linux/x86_64/lib/libssl.so.35
+        chmod +x bin/*
+        chmod +x *.sh
+
+        cd futurerestore || exit
+        unzip -o futurerestore.zip
+        tar -xf futurerestore-Linux-x86_64-v2.0.0-Build_329-RELEASE.tar.xz
+        cp futurerestore-Linux-x86_64-v2.0.0-Build_329-RELEASE/* . || true
+        chmod +x linux_fix.sh || true
+        sudo ./linux_fix.sh || true
+        rm -rf linux_fix.sh || true
+        chmod +x futurerestore
+        rm -rf *.tar.xz || true
+        rm -rf *.sh || true
+        rm -rf *.zip || true
+        rm -rf "futurerestore-Linux-x86_64-v2.0.0-Build_329-RELEASE" 
+        cd ..
+    fi
+
+
+}

--- a/scripts/core/lib/runtime_context.sh
+++ b/scripts/core/lib/runtime_context.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/runtime/prepare_environment.sh"
+. "$SCRIPT_DIR/runtime/detect_device.sh"
+. "$SCRIPT_DIR/runtime/apply_profiles.sh"
+
+runtime_error_handler() {
+    local exit_code=$?
+    local failed_command="$BASH_COMMAND"
+    local line_number="${BASH_LINENO[0]}"
+    local script_file="${BASH_SOURCE[1]:-$0}"
+
+    {
+        echo "[!] surrealra1n has crashed due to an issue"
+        echo "[!] Exit code: $exit_code"
+        echo "[!] Script: $script_file"
+        echo "[!] Line: $line_number"
+        echo "[!] Failed command: $failed_command"
+        echo
+        echo "[!] It is recommended to report this issue here:"
+        echo "    https://github.com/pwnerblu/surrealra1n/issues"
+        echo "Here's the recommended way to report this:"
+        echo "Title should be a brief and clear summary of the issue you are trying to report"
+        echo "Issue description should mention all relevant details to such issue if possible, and also a full terminal log attached."
+        echo "[!] Issues THAT DO NOT CONTAIN PROPER LOGS, DETAILS, OR ANYTHING RELEVANT, WILL BE CLOSED AS INVALID."
+        echo
+        echo "[!] To attach this log into your issue, do the following:"
+        if [[ ${dist:-0} == 3 || ${dist:-0} == 4 ]]; then
+            echo "Cmd + A -> Cmd + C, then paste the entire log into your issue you're opening"
+        else
+            echo "Ctrl + Shift + A -> Ctrl + Shift + C, then paste the entire log into the issue you're opening"
+        fi
+    }
+
+    exit "$exit_code"
+}
+
+init_runtime_context() {
+    clear
+    set -euo pipefail
+    trap 'runtime_error_handler $LINENO' ERR
+
+    prepare_runtime_environment
+    detect_connected_device
+    apply_device_profiles
+}

--- a/scripts/core/lib/usage.sh
+++ b/scripts/core/lib/usage.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+function usage() {
+    local downgrade_display="${DOWNGRADE_RANGE:-device-specific (detected after device check)}"
+
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+  --make-custom-ipsw [TARGET_IPSW_PATH] [BASE_IPSW_PATH] [iOS_VERSION]
+        Create a custom IPSW for tethered restore.
+        - TARGET_IPSW_PATH: Path for the stock IPSW for target version
+        - BASE_IPSW_PATH: Must be latest signed iOS IPSW for your device
+        - iOS_VERSION: Target iOS version to restore ($downgrade_display)
+
+  --seprmvr64-ipsw [TARGET_IPSW_PATH] [BASE_IPSW_PATH] [iOS_VERSION] [optional: --jailbreak]
+        Create a custom IPSW for tethered restore, with seprmvr64. If you're going to 9.2.1 and lower, you can choose to attempt stitching activation records to pre-activate the seprmvr64 restore.
+        - TARGET_IPSW_PATH: Path for the stock IPSW for target version
+        - BASE_IPSW_PATH: Must be latest signed iOS IPSW for your device
+        - iOS_VERSION: Target iOS version to restore
+        - [--stitch-activation]: Attempt to stitch activation records into rootfs to pre-activate a restore (7.0 - 9.2.1 only). Device must be legitimately activated to save activation records, it can't be iCloud/MDM bypassed.
+
+  --restore [iOS_VERSION]
+        Restore the device to a previously created custom IPSW.
+        - You can also choose to tethered update (no data loss, but may only work if going from a lower version to a newer version (13.6 to 15.4.1 for example)
+        - Requires a custom IPSW already built for the specified iOS version.
+        - Put your device into DFU mode before proceeding.
+
+  --seprmvr64-restore [iOS_VERSION]
+        Restore the device to a previously created custom IPSW for seprmvr64.
+        - Requires a custom IPSW already built for the specified iOS version.
+        - Put your device into DFU mode before proceeding.
+
+  --seprmvr64-boot [iOS_VERSION] [ipsw file]
+        Perform a tethered boot of the specified iOS version with seprmvr64.
+        - You must be on that iOS version already.
+        - Put your device into DFU mode before proceeding.
+
+  --fix-ios8
+        Automatically boot SSH ramdisk and patch iOS 8 dyld cache.
+        - Intended right after a fresh iOS 8.x seprmvr64 restore.
+
+  --downgrade [IPSW FILE] [SHSH BLOB]
+        Downgrade a device with SHSH blobs.
+        - NOTE: the shsh blob must be for the iOS version you're downgrading to!
+        - if you dont have shsh blobs for the version you want to downgrade to, please make a custom ipsw and use the restore flag instead to do a tethered downgrade.
+
+  --boot [iOS_VERSION]
+        Perform a tethered boot of the specified iOS version.
+        - You must be on that iOS version already.
+        - Put your device into DFU mode before proceeding.
+
+  -h, --help
+        Show this help message and exit.
+
+EOF
+}

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-CURRENT_VERSION="v1.3.17"
+CURRENT_VERSION="v1.3.21"
 
 clear
 
@@ -52,11 +52,6 @@ echo "Huge thanks to Mineek for openra1n and seprmvr64."
 echo "Enter your user password when prompted to"
 sudo -v || exit 1
 
-macmodel=$(sysctl -n hw.model) || true
-
-# Outdated macOS ver check
-macos_ver=$(sw_vers -productVersion) || true
-
 dist=0
 
 JAILBREAK=0
@@ -86,32 +81,40 @@ if [[ "$(uname)" == "Darwin" ]]; then
 elif [[ -r /etc/os-release ]]; then
     . /etc/os-release
 
-    if [[ "$ID" == "arch" || "$ID_LIKE" == *arch* ]]; then
+    if [[ "$ID" == "arch" || "${ID_LIKE:-}" == *arch* ]]; then
         DISTRO="Arch"
         dist=2
-    elif [[ "$ID" == "debian" || "$ID_LIKE" == *debian* ]]; then
+    elif [[ "$ID" == "debian" || "${ID_LIKE:-}" == *debian* ]]; then
         DISTRO="Debian"
         dist=1
         read -n 1 -s -r -p "Press any key to continue"
     fi
 fi
 
-if [[ $dist == 3 || $dist == 4 ]] && [[ "$(printf) '%s\n' "10.11" "$macos_ver" | sort -V | head -n1)" != "$macos_ver" ]]; then
-    echo "Your macOS version $macos_ver is supported."
-else
-    echo "surrealra1n only supports macOS versions after 10.11. Learn more at https://github.com/pwnerblu/surrealra1n"
-    echo "You can continue however features WILL be broken."
-    echo "Your macOS X version:$macos_ver"
-    read -n 1 -s -r -p "Press any key to continue"
-    echo
+# Run macOS version check only if you're on macOS, should fix Linux
+if [[ $dist == 3 || $dist == 4 ]]; then
+    macmodel=$(sysctl -n hw.model) 
+
+    # Outdated macOS ver check
+    macos_ver=$(sw_vers -productVersion) 
 fi
 
-if [[ "$macmodel" == "Mac17,5" ]]; then
-    echo "There is a problem with the MacBook Neo in which openra1n fails to compile."
-    echo "You cannot boot jailbroken with palera1n on tethered downgrades without openra1n, however for everything else it should be fine."
-    echo "It will be fixed soon enough."
-    read -n 1 -s -r -p "Press any key to continue"
-    echo
+if [[ $dist == 3 || $dist == 4 ]]; then
+    if [[ "$(printf '%s\n' "10.11" "$macos_ver" | sort -V | head -n1)" != "$macos_ver" ]]; then
+        echo "Your macOS version $macos_ver is supported."
+    else
+        echo "surrealra1n only supports macOS versions 10.11 and later at the moment."
+        echo "Your macOS version: $macos_ver"
+        echo "This may change in the future though"
+        exit 1
+    fi
+    if [[ "$macmodel" == "Mac17,5" ]]; then
+        echo "There is a problem with the MacBook Neo in which openra1n fails to compile."
+        echo "You cannot boot jailbroken with palera1n on tethered downgrades without openra1n, however for everything else it should be fine."
+        echo "It will be fixed soon enough."
+        read -n 1 -s -r -p "Press any key to continue"
+        echo
+    fi
 fi
 
 
@@ -147,8 +150,8 @@ if [[ $dist == 1 ]]; then
     if [ ${#MISSING_PACKAGES[@]} -ne 0 ]; then
         echo "Missing packages detected: ${MISSING_PACKAGES[*]}"
         echo "Installing missing dependencies..."
-        sudo apt update
-        sudo apt install -y "${MISSING_PACKAGES[@]}"
+        sudo apt update || true # issue workarounds
+        sudo apt install -y "${MISSING_PACKAGES[@]}" || true # issue workarounds
     else
         echo "All dependencies are installed." 
     fi
@@ -2451,6 +2454,7 @@ case "$1" in
                 mnifst="manifest/BuildManifest-iPad5,2.plist"
                 curl -L -o $mnifst https://github.com/pwnerblu/cursed-sep-resources/raw/refs/heads/main/BuildManifest-iPad5,2.plist
             fi
+            sudo rm -rf "tmp"
             mkdir tmp
             mkdir tmp/Firmware
             mkdir tmp/Firmware/all_flash

--- a/surrealra1n_new.sh
+++ b/surrealra1n_new.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+. "$SCRIPT_DIR/scripts/core/lib/bootstrap.sh"
+. "$SCRIPT_DIR/scripts/core/lib/usage.sh"
+. "$SCRIPT_DIR/scripts/core/lib/auto_update.sh"
+. "$SCRIPT_DIR/scripts/core/lib/dispatch.sh"
+
+main() {
+    bootstrap_environment
+    maybe_auto_update "$@"
+
+    if [[ $# -eq 0 ]]; then
+        usage
+        exit 1
+    fi
+
+    dispatch_command "$@"
+}
+
+main "$@"

--- a/update/latest.txt
+++ b/update/latest.txt
@@ -1,5 +1,5 @@
-v1.3.17
+v1.3.21
 
 RELEASE NOTES:
 
-improve standards for issue reporting
+More linux fixes


### PR DESCRIPTION
## Summary

This PR improves the modular architecture of `surrealra1n` and finalizes the `--fix-ios8` automation flow.

- Refined the modular split (`entrypoint -> dispatcher -> command modules -> core libs`) to reduce path/runtime issues and keep behavior consistent.
- Added/cleaned shared core logic so commands rely on reusable modules instead of duplicated inline logic.
- Implemented fully automatic `--fix-ios8`:
  - auto dependency handling,
  - auto SSH ramdisk preparation/boot,
  - automatic dyld patch flow without manual ramdisk steps.