### PR TITLE
[CRUCIAl FIX, SCRIPT DOESN'T WORK ON FEDORA] fedora package name fix

### DIFF
--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -252,7 +252,7 @@ elif [[ $dist == 2 ]]; then
         echo "All dependencies are already installed."
     fi
 elif [[ $dist == 5 ]]; then
-    DEPENDENCIES=(libusb1-devel usbmuxd libimobiledevice-utils zenity git curl make gcc python3-pip python3-usb)
+    DEPENDENCIES=(libusb1-devel usbmuxd libimobiledevice-utils zenity git curl make gcc python3-pip python3-pyusb)
     MISSING_PACKAGES=()
 
     for pkg in "${DEPENDENCIES[@]}"; do


### PR DESCRIPTION
python3-usb package is named python3-pyusb on fedora but script tries to download python3-usb instead and kaboom