### PR TITLE
rmmod after make custom ipsw on linuxadd rmmod

### DIFF
--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -2569,7 +2569,7 @@ rm -rf "tmp1"
 rm -rf "tmp2"
 mv -v custom.ipsw $restoredir/custom.ipsw
 rm -rf "work"
-
+sudo rmmod apfs
 }
 
 make_custom_ipsw_a12_ios14(){


### PR DESCRIPTION
If you don't run rmmod apfs after insmod apfs.ko, next time when you do insmod you'll get an error: File exists
<img width="901" height="377" alt="截图 2026-08-12 19-21-35" src="https://github.com/user-attachments/assets/109a03b9-2fc7-45af-b3e8-5a7504c5566d" />
