### PR TITLE
Allow using MacPorts for installing deps

### DIFF
--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -215,6 +215,9 @@ if [[ $dist == 3 || $dist == 4 ]]; then
 	    darwin_package_manager=2
     else
 	    echo "No package manager installed. Please install Homebrew or MacPorts."
+	    # These need to be updated once macOS 27 Golden Gate is released.
+	    echo "Homebrew is recommended on Macs running macOS 14 Sonoma or later: https://brew.sh"
+	    echo "MacPorts is recommended on Macs running macOS 13 Ventura or earlier: https://macports.org"
 	    exit 1
     fi
 

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -210,7 +210,7 @@ if [[ $dist == 3 || $dist == 4 ]]; then
     if command -v brew &>/dev/null; then
 	    echo "Using Homebrew"
 	    darwin_package_manager=1
-        if [[ "$(printf '%s\n' "14.0" "$macos_ver" | sort -V | head -n1)" == "14.0" ]]; then
+        if [[ "$(printf '%s\n' "14.0" "$macos_ver" | sort -V | head -n1)" != "14.0" ]]; then
             echo "Using Homebrew is not recommended on your macOS version ($macos_ver)."
         fi
         if command -v port &>/dev/null; then

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -205,13 +205,6 @@ if [[ $dist == 3 || $dist == 4 ]]; then
         echo "Xcode Command Line Tools are installed."
     fi
 
-    # Check for Homebrew
-    #if ! command -v brew &>/dev/null; then
-    #    echo "[!] Homebrew is not installed. You will need to install Homebrew from https://brew.sh"
-    #    exit 1
-    #else
-    #    echo "Homebrew is installed."
-    #fi
    
     if command -v brew &>/dev/null; then
 	    echo "Using homebrew"
@@ -223,19 +216,6 @@ if [[ $dist == 3 || $dist == 4 ]]; then
 	    echo "No package manager installed. Please install Homebrew or MacPorts."
 	    exit 1
     fi
-
-
-    # Check for missing brew dependencies
-#    BREW_DEPS=("libimobiledevice" "libirecovery" "binutils" "libusb" "jq" "aria2")
-#    for dep in "${BREW_DEPS[@]}"; do
-#        if ! brew list "$dep" &>/dev/null; then
-#            echo "[$dep] is not installed. Installing..."
-#            brew install "$dep"
-#        else
-#            echo "[$dep] is installed."
-#        fi
-#    done
-#fi
 
 
     DEPS=("libimobiledevice" "libirecovery" "binutils" "libusb" "jq" "aria2")

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -251,7 +251,7 @@ if [[ $dist == 3 || $dist == 4 ]]; then
        for dep in "${DEPS[@]}"; do
 	   if ! port installed | grep "$dep" &>/dev/null; then
  		   echo "[$dep] is not installed. Installing..."
-	 	   sudo port install "$dep"
+	 	   sudo port -N install "$dep"
            else
 		   echo "[$dep] is installed."
            fi

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -213,6 +213,7 @@ if [[ $dist == 3 || $dist == 4 ]]; then
         if [[ "$(printf '%s\n' "14.0" "$macos_ver" | sort -V | head -n1)" != "14.0" ]]; then
             echo "Using Homebrew is not recommended on your macOS version ($macos_ver)."
         fi
+        # Need to see if there's a way of doing this that doesn't prompt the user on every start
         if command -v port &>/dev/null; then
             read -r -p "Use MacPorts instead? [y/n]" yn
             if [[ $yn =~ ^[yY] ]]; then

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -20,6 +20,7 @@ VERSION=""
 BUILD=""
 VERSION_LATEST=""
 outdated=""
+package_manager_darwin=0
 
 set -euo pipefail
 
@@ -211,6 +212,17 @@ if [[ $dist == 3 || $dist == 4 ]]; then
     #else
     #    echo "Homebrew is installed."
     #fi
+   
+    if command -v brew &>/dev/null; then
+	    echo "Using homebrew"
+	    darwin_package_manager=1
+    elif command -v port &>/dev/null; then
+	    echo "Using macports"
+	    darwin_package_manager=2
+    else
+	    echo "No package manager installed. Please install Homebrew or MacPorts."
+    fi
+
 
     # Check for missing brew dependencies
     BREW_DEPS=("libimobiledevice" "libirecovery" "binutils" "libusb" "jq" "aria2")

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -208,10 +208,10 @@ if [[ $dist == 3 || $dist == 4 ]]; then
     # Check if either Homebrew or MacPorts is installed. brew is prioritized, might be worth changing this though.
    
     if command -v brew &>/dev/null; then
-	    echo "Using homebrew"
+	    echo "Using Homebrew"
 	    darwin_package_manager=1
     elif command -v port &>/dev/null; then
-	    echo "Using macports"
+	    echo "Using MacPorts"
 	    darwin_package_manager=2
     else
 	    echo "No package manager installed. Please install Homebrew or MacPorts."

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -210,6 +210,14 @@ if [[ $dist == 3 || $dist == 4 ]]; then
     if command -v brew &>/dev/null; then
 	    echo "Using Homebrew"
 	    darwin_package_manager=1
+        if [[ "$(printf '%s\n' "14.0" "$macos_ver" | sort -V | head -n1)" == "14.0" ]]; then
+            echo "Using Homebrew is not recommended on your macOS version ($macos_ver)."
+            if command -v port &>/dev/null; then
+                read -r -p "Use MacPorts instead? [y/n]" yn
+                if [[ $yn =~ ^[yY] ]]; then
+                    darwin_package_manager=2
+                fi
+            fi
     elif command -v port &>/dev/null; then
 	    echo "Using MacPorts"
 	    darwin_package_manager=2

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -21,6 +21,7 @@ BUILD=""
 VERSION_LATEST=""
 outdated=""
 package_manager_darwin=0
+BREW_MIN="14.0"
 
 set -euo pipefail
 
@@ -210,7 +211,7 @@ if [[ $dist == 3 || $dist == 4 ]]; then
     if command -v brew &>/dev/null; then
 	    echo "Using Homebrew"
 	    darwin_package_manager=1
-        if [[ "$(printf '%s\n' "14.0" "$macos_ver" | sort -V | head -n1)" != "14.0" ]]; then
+        if [[ "$(printf '%s\n' "$BREW_MIN" "$macos_ver" | sort -V | head -n1)" != "$BREW_MIN" ]]; then
             echo "Using Homebrew is not recommended on your macOS version ($macos_ver)."
         fi
         # Need to see if there's a way of doing this that doesn't prompt the user on every start

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -212,12 +212,12 @@ if [[ $dist == 3 || $dist == 4 ]]; then
 	    darwin_package_manager=1
         if [[ "$(printf '%s\n' "14.0" "$macos_ver" | sort -V | head -n1)" == "14.0" ]]; then
             echo "Using Homebrew is not recommended on your macOS version ($macos_ver)."
-            if command -v port &>/dev/null; then
-                read -r -p "Use MacPorts instead? [y/n]" yn
-                if [[ $yn =~ ^[yY] ]]; then
-                    darwin_package_manager=2
-                fi
-            fi
+        fi
+        if command -v port &>/dev/null; then
+            read -r -p "Use MacPorts instead? [y/n]" yn
+            if [[ $yn =~ ^[yY] ]]; then
+                darwin_package_manager=2
+        fi
     elif command -v port &>/dev/null; then
 	    echo "Using MacPorts"
 	    darwin_package_manager=2

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -205,6 +205,7 @@ if [[ $dist == 3 || $dist == 4 ]]; then
         echo "Xcode Command Line Tools are installed."
     fi
 
+    # Check if either Homebrew or MacPorts is installed. brew is prioritized, might be worth changing this though.
    
     if command -v brew &>/dev/null; then
 	    echo "Using homebrew"
@@ -217,7 +218,7 @@ if [[ $dist == 3 || $dist == 4 ]]; then
 	    exit 1
     fi
 
-
+    # Install dependencies using either brew or port. Both package managers conveniently use the same names for each package
     DEPS=("libimobiledevice" "libirecovery" "binutils" "libusb" "jq" "aria2")
     if [[ $darwin_package_manager -eq 1 ]]; then
        for dep in "${DEPS[@]}"; do

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -205,12 +205,12 @@ if [[ $dist == 3 || $dist == 4 ]]; then
     fi
 
     # Check for Homebrew
-    if ! command -v brew &>/dev/null; then
-        echo "[!] Homebrew is not installed. You will need to install Homebrew from https://brew.sh"
-        exit 1
-    else
-        echo "Homebrew is installed."
-    fi
+    #if ! command -v brew &>/dev/null; then
+    #    echo "[!] Homebrew is not installed. You will need to install Homebrew from https://brew.sh"
+    #    exit 1
+    #else
+    #    echo "Homebrew is installed."
+    #fi
 
     # Check for missing brew dependencies
     BREW_DEPS=("libimobiledevice" "libirecovery" "binutils" "libusb" "jq" "aria2")

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -216,7 +216,7 @@ if [[ $dist == 3 || $dist == 4 ]]; then
         fi
         # Need to see if there's a way of doing this that doesn't prompt the user on every start
         if command -v port &>/dev/null; then
-            read -r -p "Use MacPorts instead? [y/n]" yn
+            read -r -p "Use MacPorts instead? [y/n] " yn
             if [[ $yn =~ ^[yY] ]]; then
                 darwin_package_manager=2
             fi

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -19,9 +19,8 @@ restorefiles_remake=""
 VERSION=""
 BUILD=""
 VERSION_LATEST=""
-outdated=""
-package_manager_darwin=0
 BREW_MIN="14.0"
+outdated=""
 
 set -euo pipefail
 

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -225,16 +225,16 @@ if [[ $dist == 3 || $dist == 4 ]]; then
 
 
     # Check for missing brew dependencies
-    BREW_DEPS=("libimobiledevice" "libirecovery" "binutils" "libusb" "jq" "aria2")
-    for dep in "${BREW_DEPS[@]}"; do
-        if ! brew list "$dep" &>/dev/null; then
-            echo "[$dep] is not installed. Installing..."
-            brew install "$dep"
-        else
-            echo "[$dep] is installed."
-        fi
-    done
-fi
+#    BREW_DEPS=("libimobiledevice" "libirecovery" "binutils" "libusb" "jq" "aria2")
+#    for dep in "${BREW_DEPS[@]}"; do
+#        if ! brew list "$dep" &>/dev/null; then
+#            echo "[$dep] is not installed. Installing..."
+#            brew install "$dep"
+#        else
+#            echo "[$dep] is installed."
+#        fi
+#    done
+#fi
 
 # Check for Rosetta 2 (Apple Silicon only)
 if [[ $dist == 3 ]]; then

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -221,7 +221,7 @@ if [[ $dist == 3 || $dist == 4 ]]; then
 	    exit 1
     fi
 
-    # Install dependencies using either brew or port. Both package managers conveniently use the same names for each package
+    # Install dependencies using either brew or port. Both package managers conveniently use the same names for each package.
     DEPS=("libimobiledevice" "libirecovery" "binutils" "libusb" "jq" "aria2")
     if [[ $darwin_package_manager -eq 1 ]]; then
        for dep in "${DEPS[@]}"; do

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -217,6 +217,7 @@ if [[ $dist == 3 || $dist == 4 ]]; then
             read -r -p "Use MacPorts instead? [y/n]" yn
             if [[ $yn =~ ^[yY] ]]; then
                 darwin_package_manager=2
+            fi
         fi
     elif command -v port &>/dev/null; then
 	    echo "Using MacPorts"

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -221,6 +221,7 @@ if [[ $dist == 3 || $dist == 4 ]]; then
 	    darwin_package_manager=2
     else
 	    echo "No package manager installed. Please install Homebrew or MacPorts."
+	    exit 1
     fi
 
 
@@ -257,7 +258,6 @@ if [[ $dist == 3 || $dist == 4 ]]; then
            fi
        done
     fi
-
 fi	
 
 

--- a/surrealra1n.sh
+++ b/surrealra1n.sh
@@ -236,6 +236,31 @@ if [[ $dist == 3 || $dist == 4 ]]; then
 #    done
 #fi
 
+
+    DEPS=("libimobiledevice" "libirecovery" "binutils" "libusb" "jq" "aria2")
+    if [[ $darwin_package_manager -eq 1 ]]; then
+       for dep in "${DEPS[@]}"; do
+           if ! brew list "$dep" &>/dev/null; then
+               echo "[$dep] is not installed. Installing..."
+               brew install "$dep"
+           else
+               echo "[$dep] is installed."
+           fi
+       done
+    else
+       for dep in "${DEPS[@]}"; do
+	   if ! port installed | grep "$dep" &>/dev/null; then
+ 		   echo "[$dep] is not installed. Installing..."
+	 	   sudo port install "$dep"
+           else
+		   echo "[$dep] is installed."
+           fi
+       done
+    fi
+
+fi	
+
+
 # Check for Rosetta 2 (Apple Silicon only)
 if [[ $dist == 3 ]]; then
     if ! /usr/bin/pgrep -q oahd; then


### PR DESCRIPTION
Allows using MacPorts instead of Homebrew for installing the dependencies.

This is ***especially*** useful for Macs on macOS 13 Ventura and earlier, which no longer have support from Homebrew as of writing this PR, which means `brew` attempts to compile every package. This is unsurprisingly a very slow process, especially if you're running on a Mac that is EOL on Sonoma or later, which usually have CPUs that are *very* weak and often times dual core. MacPorts on the other hand still offers precompiled binaries and an easy installation for versions going all the way back to Mac OS X 10.5 Leopard. 

These changes work fine on macOS 12 Monterey, but probably needs a bit more testing. Marking this as a draft PR for now since it still needs a few more changes.